### PR TITLE
Redesign webviews and command UX to be dev-friendly

### DIFF
--- a/media/webview/settings/index.html
+++ b/media/webview/settings/index.html
@@ -4,166 +4,156 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src {{cspSource}} 'unsafe-inline'; script-src 'nonce-{{nonce}}'; img-src {{cspSource}} https: data:;">
-    <title>FlowCraft Settings</title>
-    
+    <title>FlowCraft · settings</title>
+
     <link rel="stylesheet" href="{{themeCss}}">
     <link rel="stylesheet" href="{{componentsCss}}">
     <link rel="stylesheet" href="{{settingsCss}}">
     <link rel="stylesheet" href="{{codiconCss}}">
 </head>
 <body>
-    <div class="settings-container">
-        <div class="header">
-            <h1>Settings</h1>
-            <div class="header-actions">
-                <button class="btn-icon" id="reset-btn" title="Reset to defaults">
-                    <i class="codicon codicon-refresh"></i>
+    <main class="st">
+
+        <header class="st-head">
+            <div class="st-path">
+                <span class="muted">flowcraft</span>
+                <span class="dim">/</span>
+                <span>settings.toml</span>
+            </div>
+            <div class="st-actions">
+                <button class="btn-icon" id="reveal-btn" title="show / hide keys">
+                    <i class="codicon codicon-eye"></i>
+                </button>
+                <button class="btn-icon" id="reset-btn" title="reset to defaults (⌘R)">
+                    <i class="codicon codicon-debug-restart"></i>
                 </button>
             </div>
-        </div>
+        </header>
 
-        <!-- AI Providers Section -->
-        <div class="section">
-            <div class="section-header">
-                <div class="section-title">AI Providers</div>
+        <!-- ————— providers ————— -->
+        <section class="st-section">
+            <span class="section-marker">providers · byok</span>
+
+            <!-- OpenAI -->
+            <div class="row">
+                <div class="row-head">
+                    <span class="row-key"><span class="prefix">api.</span>openai</span>
+                    <span class="row-hint">gpt-4o · gpt-4 · gpt-3.5 · prefix <code>sk-</code></span>
+                </div>
+                <div class="row-control">
+                    <input type="password" class="input" id="key-openai" placeholder="sk-…" autocomplete="off" spellcheck="false">
+                    <button class="btn btn-sm" id="test-openai">test</button>
+                </div>
+                <div class="row-foot">
+                    <span id="status-openai" class="status">unset</span>
+                    <span class="dim">stored in vscode.secrets</span>
+                </div>
             </div>
-            <div class="section-content">
-                
-                <!-- OpenAI -->
-                <div class="form-row top-align">
-                    <div class="form-label">
-                        OpenAI
-                        <div class="form-helper">GPT-4, GPT-3.5 Turbo</div>
-                    </div>
-                    <div class="form-control api-key-container">
-                        <div class="api-key-input-group">
-                            <input type="password" class="input" id="key-openai" placeholder="sk-None...">
-                        </div>
-                        <div class="flex justify-between items-center" style="margin-top: 6px;">
-                             <div class="form-helper" id="status-openai">Securely stored</div>
-                             <button class="btn btn-secondary" id="test-openai" style="font-size: 11px; padding: 4px 10px;">Test Connection</button>
-                        </div>
-                    </div>
-                </div>
 
-                <!-- Anthropic -->
-                <div class="form-row top-align">
-                    <div class="form-label">
-                        Anthropic
-                        <div class="form-helper">Claude 3 Opus, Sonnet</div>
-                    </div>
-                    <div class="form-control api-key-container">
-                        <div class="api-key-input-group">
-                            <input type="password" class="input" id="key-anthropic" placeholder="sk-ant-...">
-                        </div>
-                        <div class="flex justify-between items-center" style="margin-top: 6px;">
-                             <div class="form-helper" id="status-anthropic">Securely stored</div>
-                             <button class="btn btn-secondary" id="test-anthropic" style="font-size: 11px; padding: 4px 10px;">Test Connection</button>
-                        </div>
-                    </div>
+            <!-- Anthropic -->
+            <div class="row">
+                <div class="row-head">
+                    <span class="row-key"><span class="prefix">api.</span>anthropic</span>
+                    <span class="row-hint">claude 3 opus · sonnet · haiku · prefix <code>sk-ant-</code></span>
                 </div>
-
-                <!-- Google -->
-                <div class="form-row top-align">
-                    <div class="form-label">
-                        Google
-                        <div class="form-helper">Gemini Pro</div>
-                    </div>
-                    <div class="form-control api-key-container">
-                        <div class="api-key-input-group">
-                            <input type="password" class="input" id="key-google" placeholder="AIza...">
-                        </div>
-                        <div class="flex justify-between items-center" style="margin-top: 6px;">
-                             <div class="form-helper" id="status-google">Securely stored</div>
-                             <button class="btn btn-secondary" id="test-google" style="font-size: 11px; padding: 4px 10px;">Test Connection</button>
-                        </div>
-                    </div>
+                <div class="row-control">
+                    <input type="password" class="input" id="key-anthropic" placeholder="sk-ant-…" autocomplete="off" spellcheck="false">
+                    <button class="btn btn-sm" id="test-anthropic">test</button>
                 </div>
-
-                <!-- FlowCraft (Native) -->
-                <div class="form-row top-align">
-                    <div class="form-label">
-                        FlowCraft Cloud
-                        <div class="form-helper">Specialized Models</div>
-                    </div>
-                    <div class="form-control api-key-container">
-                        <div class="api-key-input-group">
-                            <input type="password" class="input" id="key-flowcraft" placeholder="fc_...">
-                        </div>
-                        <div class="flex justify-between items-center" style="margin-top: 6px;">
-                             <div class="form-helper" id="status-flowcraft">Account token</div>
-                             <button class="btn btn-secondary" id="test-flowcraft" style="font-size: 11px; padding: 4px 10px;">Test Connection</button>
-                        </div>
-                    </div>
+                <div class="row-foot">
+                    <span id="status-anthropic" class="status">unset</span>
+                    <span class="dim">stored in vscode.secrets</span>
                 </div>
-
             </div>
-        </div>
 
-        <!-- General Preferences -->
-        <div class="section">
-            <div class="section-header">
-                <div class="section-title">Preferences</div>
+            <!-- Google -->
+            <div class="row">
+                <div class="row-head">
+                    <span class="row-key"><span class="prefix">api.</span>google</span>
+                    <span class="row-hint">gemini pro · prefix <code>AIza</code></span>
+                </div>
+                <div class="row-control">
+                    <input type="password" class="input" id="key-google" placeholder="AIza…" autocomplete="off" spellcheck="false">
+                    <button class="btn btn-sm" id="test-google">test</button>
+                </div>
+                <div class="row-foot">
+                    <span id="status-google" class="status">unset</span>
+                    <span class="dim">stored in vscode.secrets</span>
+                </div>
             </div>
-            <div class="section-content">
-                
-                <div class="form-row">
-                    <label class="form-label" for="default-provider">Default Provider</label>
-                    <div class="form-control">
-                        <select class="input" id="default-provider" style="width: auto; min-width: 140px;">
-                            <option value="openai">OpenAI</option>
-                            <option value="anthropic">Anthropic</option>
-                            <option value="google">Google</option>
-                            <option value="flowcraft">FlowCraft Cloud</option>
-                        </select>
-                    </div>
-                </div>
 
-                <div class="form-row">
-                    <label class="form-label" for="default-type">Default Diagram</label>
-                    <div class="form-control">
-                         <select class="input" id="default-type" style="width: auto; min-width: 140px;">
-                            <option value="flowchart">Flowchart</option>
-                            <option value="sequence">Sequence Diagram</option>
-                            <option value="class">Class Diagram</option>
-                            <option value="state">State Diagram</option>
-                            <option value="er">ER Diagram</option>
-                            <option value="gantt">Gantt Chart</option>
-                            <option value="pie">Pie Chart</option>
-                        </select>
-                    </div>
+            <!-- FlowCraft -->
+            <div class="row">
+                <div class="row-head">
+                    <span class="row-key"><span class="prefix">api.</span>flowcraft</span>
+                    <span class="row-hint">native cloud · prefix <code>fc_</code></span>
                 </div>
-
-                <div class="form-row">
-                    <label class="form-label" for="default-palette">Default Colors</label>
-                    <div class="form-control">
-                        <select class="input" id="default-palette" style="width: auto; min-width: 140px;">
-                            <option value="brand colors">Brand Colors</option>
-                            <option value="monochromatic">Monochromatic</option>
-                            <option value="complementary">Complementary</option>
-                            <option value="analogous">Analogous</option>
-                        </select>
-                    </div>
+                <div class="row-control">
+                    <input type="password" class="input" id="key-flowcraft" placeholder="fc_…" autocomplete="off" spellcheck="false">
+                    <button class="btn btn-sm" id="test-flowcraft">test</button>
                 </div>
-
-                <div class="form-row">
-                    <label class="form-label" for="default-complexity">Complexity</label>
-                    <div class="form-control">
-                        <select class="input" id="default-complexity" style="width: auto; min-width: 140px;">
-                            <option value="simple">Simple</option>
-                            <option value="medium">Medium</option>
-                            <option value="complex">Complex</option>
-                        </select>
-                    </div>
+                <div class="row-foot">
+                    <span id="status-flowcraft" class="status">unset</span>
+                    <span class="dim">stored in vscode.secrets</span>
                 </div>
-                
             </div>
-        </div>
-    </div>
+        </section>
 
-    <div class="actions-bar">
-        <button class="btn btn-primary" id="save-btn" style="min-width: 120px;">Save Changes</button>
-    </div>
+        <!-- ————— preferences ————— -->
+        <section class="st-section">
+            <span class="section-marker">defaults</span>
+
+            <div class="row row-inline">
+                <span class="row-key"><span class="prefix">default.</span>provider</span>
+                <select class="input input-inline" id="default-provider">
+                    <option value="openai">openai</option>
+                    <option value="anthropic">anthropic</option>
+                    <option value="google">google</option>
+                    <option value="flowcraft">flowcraft</option>
+                </select>
+            </div>
+
+            <div class="row row-inline">
+                <span class="row-key"><span class="prefix">default.</span>diagram</span>
+                <select class="input input-inline" id="default-type">
+                    <option value="flowchart">flowchart</option>
+                    <option value="sequence">sequence</option>
+                    <option value="class">class</option>
+                    <option value="state">state</option>
+                    <option value="er">er</option>
+                    <option value="gantt">gantt</option>
+                    <option value="pie">pie</option>
+                </select>
+            </div>
+
+            <div class="row row-inline">
+                <span class="row-key"><span class="prefix">default.</span>palette</span>
+                <select class="input input-inline" id="default-palette">
+                    <option value="brand colors">brand</option>
+                    <option value="monochromatic">monochromatic</option>
+                    <option value="complementary">complementary</option>
+                    <option value="analogous">analogous</option>
+                </select>
+            </div>
+
+            <div class="row row-inline">
+                <span class="row-key"><span class="prefix">default.</span>complexity</span>
+                <select class="input input-inline" id="default-complexity">
+                    <option value="simple">simple</option>
+                    <option value="medium">medium</option>
+                    <option value="complex">complex</option>
+                </select>
+            </div>
+        </section>
+
+    </main>
+
+    <footer class="st-foot">
+        <span class="st-foot-cell"><span class="dim">⌘S</span> save</span>
+        <span class="st-foot-cell"><span class="dim">⌘R</span> reset</span>
+        <span class="st-foot-cell" id="foot-status">idle</span>
+        <button class="btn btn-primary" id="save-btn">save changes</button>
+    </footer>
 
     <script type="module" nonce="{{nonce}}" src="{{settingsJs}}"></script>
 </body>

--- a/media/webview/settings/settings.css
+++ b/media/webview/settings/settings.css
@@ -1,251 +1,117 @@
-/* Settings View Specific Styles - Apple Aesthetic Minimalist */
+/* Settings — config-file layout */
 
-body {
-  padding: var(--spacing-lg);
-  overflow-x: hidden;
-  background-color: var(--color-bg);
-  color: var(--color-text-primary);
-}
+body { padding: 0; overflow-x: hidden; }
 
-.settings-container {
-  max-width: 680px; /* Optimal reading width */
-  margin: 0 auto;
-  padding-bottom: 80px; /* Space for sticky footer */
-}
-
-/* Header */
-.header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-bottom: var(--spacing-xl);
-  padding: 0 var(--spacing-sm);
-}
-
-.header h1 {
-  font-size: 34px;
-  font-weight: 700;
-  letter-spacing: -0.5px;
-}
-
-.header-actions {
-  display: flex;
-  gap: var(--spacing-md);
-}
-
-.btn-icon {
-  background: transparent;
-  border: none;
-  color: var(--color-primary);
-  border-radius: 50%;
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background-color var(--transition-fast);
-  cursor: pointer;
-}
-
-.btn-icon:hover {
-  background-color: rgba(128, 128, 128, 0.1);
-}
-
-.btn-icon i {
-  font-size: 16px;
-}
-
-/* Sections / Groups */
-.section {
-  margin-bottom: var(--spacing-xl);
-}
-
-.section-header {
-  padding: 0 var(--spacing-md) var(--spacing-sm);
-  margin-bottom: var(--spacing-xs);
-}
-
-.section-title {
-  font-size: 13px;
-  text-transform: uppercase;
-  color: var(--color-text-secondary);
-  font-weight: 500;
-  letter-spacing: -0.2px;
-}
-
-.section-content {
-  background-color: var(--color-surface);
-  border-radius: var(--radius-md);
-  overflow: hidden;
-  /* No border, rely on background contrast or shadow */
-  box-shadow: var(--shadow-sm); 
-}
-
-
-/* Form Items - Apple Style Lists */
-.form-row {
-  display: flex;
-  align-items: center;
-  padding: var(--spacing-md) var(--spacing-lg);
-  background-color: var(--color-surface);
-  border-bottom: 1px solid var(--color-divider);
-  min-height: 44px;
-}
-
-.form-row:last-child {
-  border-bottom: none;
-}
-
-.form-row.top-align {
-  align-items: flex-start;
-}
-
-.form-label {
-  flex: 1;
-  font-size: var(--font-size-md);
-  color: var(--color-text-primary);
-  font-weight: 400;
-}
-
-.form-control {
-  flex: 2;
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-}
-
-/* Inputs */
-.input {
-  width: 100%; 
-  padding: 8px 12px;
-  font-size: var(--font-size-md);
-  border: 1px solid transparent;
-  background-color: var(--color-bg); /* Light grey bg inside white card */
-  border-radius: var(--radius-sm);
-  color: var(--color-text-primary);
-  transition: all var(--transition-fast);
-  font-family: var(--font-family-mono);
-}
-
-.input:focus {
-  outline: none;
-  background-color: var(--color-surface-elevated);
-  box-shadow: 0 0 0 2px var(--color-primary);
-}
-
-/* Select inputs need specific styling to look good */
-select.input {
-  font-family: var(--font-family-body);
-  cursor: pointer;
-}
-
-/* API Key Specifics */
-.api-key-container {
+.st {
+  padding: var(--fc-sp-5);
+  padding-bottom: 72px; /* room for sticky footer */
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-sm);
-  width: 100%;
+  gap: var(--fc-sp-7);
+  max-width: 820px;
+  margin: 0 auto;
 }
 
-.api-key-input-group {
+/* Head ——————————————————————————— */
+.st-head {
   display: flex;
-  gap: var(--spacing-sm);
-  width: 100%;
-}
-
-.api-key-input-group .input {
-  flex-grow: 1;
-}
-
-.form-helper {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-secondary);
-  padding-top: 4px;
-}
-
-.provider-status-badge {
-    font-size: 11px;
-    padding: 2px 8px;
-    border-radius: 12px;
-    font-weight: 500;
-    background-color: var(--color-bg);
-    color: var(--color-text-secondary);
-}
-
-.provider-status-badge.configured {
-    color: var(--color-text-inverse);
-    background-color: var(--color-text-primary); /* Black badge */
-}
-
-/* Buttons */
-.btn {
-  padding: 6px 16px;
-  border-radius: 18px; /* Pill shape */
-  border: none;
-  font-size: var(--font-size-sm);
-  font-weight: 500;
-  cursor: pointer;
-  transition: opacity var(--transition-fast);
-}
-
-.btn:hover {
-  opacity: 0.8;
-}
-
-.btn:active {
-  opacity: 0.6;
-}
-
-.btn:disabled {
-  opacity: 0.3;
-  cursor: default;
-}
-
-.btn-primary {
-  background-color: var(--color-primary);
-  color: var(--color-text-inverse);
-}
-
-.btn-secondary {
-  background-color: var(--color-bg);
-  color: var(--color-text-primary);
-}
-
-/* Footer Actions */
-.actions-bar {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  background-color: rgba(255, 255, 255, 0.8); /* Translucent */
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  padding: var(--spacing-md) var(--spacing-xl);
-  border-top: 1px solid var(--color-divider);
-  display: flex;
-  justify-content: flex-end;
   align-items: center;
-  z-index: var(--z-sticky);
+  justify-content: space-between;
+  gap: var(--fc-sp-4);
+  padding-bottom: var(--fc-sp-4);
+  border-bottom: 1px dashed var(--fc-border);
+}
+.st-path {
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs-md);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.st-path .dim { color: var(--fc-fg-dim); }
+.st-actions { display: inline-flex; gap: var(--fc-sp-2); }
+
+/* Sections ——————————————————————————— */
+.st-section {
+  display: flex;
+  flex-direction: column;
 }
 
-/* Dark mode adjustment for backdrop */
-body[data-vscode-theme-kind="vscode-dark"] .actions-bar,
-body[data-vscode-theme-kind="vscode-high-contrast"] .actions-bar {
-  background-color: rgba(28, 28, 30, 0.8);
+/* Row overrides ——————————————————————————— */
+.row code {
+  padding: 0 3px;
+  background: var(--fc-surface);
+  border: 1px solid var(--fc-border);
+  border-radius: 2px;
+  color: var(--fc-fg);
+  font-size: 10px;
 }
 
-.spinner {
-    border: 2px solid rgba(0,0,0,0.1);
-    border-left-color: currentColor;
-    border-radius: 50%;
-    display: inline-block;
-    animation: spin 1s linear infinite;
+.row-inline {
+  display: grid;
+  grid-template-columns: minmax(200px, 1fr) auto;
+  align-items: center;
+  padding: var(--fc-sp-4) 0;
+  gap: var(--fc-sp-5);
 }
-body[data-vscode-theme-kind="vscode-dark"] .spinner {
-    border-color: rgba(255,255,255,0.1);
-    border-left-color: currentColor;
+.row-inline .row-key {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+}
+.input-inline {
+  width: auto;
+  min-width: 160px;
+  padding: var(--fc-sp-2) var(--fc-sp-4);
+  padding-right: 28px;
 }
 
-@keyframes spin {
-  to { transform: rotate(360deg); }
+/* Status text ——————————————————————————— */
+.status {
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs-sm);
+  color: var(--fc-fg-muted);
+}
+.status.ok  { color: var(--fc-ok); }
+.status.err { color: var(--fc-err); }
+.status.warn { color: var(--fc-warn); }
+.status::before {
+  content: "● ";
+  color: currentColor;
+  opacity: 0.75;
+}
+
+/* Footer action bar (sticky) ——————————————————————————— */
+.st-foot {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--fc-sp-5);
+  padding: var(--fc-sp-3) var(--fc-sp-5);
+  background: color-mix(in srgb, var(--fc-bg) 88%, transparent);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-top: 1px solid var(--fc-border);
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs-sm);
+  color: var(--fc-fg-muted);
+  z-index: 10;
+}
+.st-foot-cell { display: inline-flex; align-items: center; gap: 6px; }
+.st-foot .dim { color: var(--fc-fg-dim); }
+.st-foot #save-btn { margin-left: auto; }
+
+/* Entrance */
+.st-head, .st-section { animation: st-in 220ms ease-out both; }
+.st-section:nth-of-type(2) { animation-delay: 40ms; }
+.st-section:nth-of-type(3) { animation-delay: 80ms; }
+
+@keyframes st-in {
+  from { opacity: 0; transform: translateY(3px); }
+  to   { opacity: 1; transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .st-head, .st-section { animation: none; }
 }

--- a/media/webview/settings/settings.js
+++ b/media/webview/settings/settings.js
@@ -1,169 +1,131 @@
 import { postMessage, onMessage } from '../shared/utils/messaging.js';
 import { getById, queryAll } from '../shared/utils/dom.js';
 
+const PROVIDERS = ['openai', 'anthropic', 'google', 'flowcraft'];
+
 let currentSettings = {};
 let currentProviders = {};
+let keysRevealed = false;
 
 document.addEventListener('DOMContentLoaded', () => {
-  // Load initial settings
   postMessage('loadSettings');
+  wire();
 
-  // Setup interactions
-  setupEventListeners();
-
-  // Message handler
   onMessage({
-    updateSettings: (data) => {
-      currentSettings = data.settings;
-      currentProviders = data.providers;
-      renderSettings();
+    updateSettings: ({ settings, providers }) => {
+      currentSettings = settings;
+      currentProviders = providers;
+      render();
     },
-    connectionResult: (data) => {
-      const statusEl = getById(`status-${data.provider}`);
-      if (statusEl) {
-        statusEl.textContent = data.message;
-        // Reset class then add specific color
-        statusEl.className = 'form-helper';
-        if (data.success) {
-            statusEl.textContent = 'Connection Verified';
-            statusEl.style.color = 'var(--color-success)'; // using style directly or class if defined
-        } else {
-            statusEl.style.color = 'var(--color-error)';
-        }
-      }
-      
-      // Re-enable button
-      const btn = getById(`test-${data.provider}`);
-      if (btn) {
-        btn.disabled = false;
-        btn.innerHTML = 'Test Connection';
-      }
+    connectionResult: ({ provider, success, message }) => {
+      setStatus(provider, success ? 'ok' : 'err', success ? 'verified' : (message || 'failed'));
+      const btn = getById(`test-${provider}`);
+      if (btn) { btn.disabled = false; btn.textContent = 'test'; }
     },
-    saveComplete: (data) => {
+    saveComplete: ({ success }) => {
       const btn = getById('save-btn');
+      const foot = getById('foot-status');
       if (btn) {
-        if (data.success) {
-          btn.textContent = 'Saved ✓';
-          setTimeout(() => {
-            btn.textContent = 'Save Changes';
-            btn.disabled = false;
-          }, 1500);
-        } else {
-          btn.textContent = 'Save Failed';
-          setTimeout(() => {
-            btn.textContent = 'Save Changes';
-            btn.disabled = false;
-          }, 2000);
-        }
+        btn.textContent = success ? 'saved' : 'save failed';
+        btn.disabled = false;
+        setTimeout(() => { btn.textContent = 'save changes'; }, 1400);
+      }
+      if (foot) {
+        foot.textContent = success ? 'changes written' : 'write failed';
+        foot.className = 'st-foot-cell ' + (success ? 'ok' : 'err');
+        setTimeout(() => { foot.textContent = 'idle'; foot.className = 'st-foot-cell'; }, 1800);
       }
     }
   });
 });
 
-function setupEventListeners() {
-  // Test connection buttons
+function wire() {
+  // Test buttons
   queryAll('[id^="test-"]').forEach(btn => {
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
       const provider = btn.id.replace('test-', '');
       const input = getById(`key-${provider}`);
-      const apiKey = input.value;
-
+      const apiKey = input && input.value;
       if (!apiKey) {
-        const statusEl = getById(`status-${provider}`);
-        statusEl.textContent = 'Enter an API key first';
-        statusEl.style.color = 'var(--color-error)';
+        setStatus(provider, 'err', 'enter a key first');
         return;
       }
-
       btn.disabled = true;
-      btn.innerHTML = '<div class="spinner" style="width: 12px; height: 12px; border-width: 2px;"></div> Checking...';
-      
-      postMessage('testConnection', {
-        provider,
-        apiKey
-      });
+      btn.textContent = '…';
+      setStatus(provider, 'warn', 'checking…');
+      postMessage('testConnection', { provider, apiKey });
     });
   });
 
-  // Save button
-  getById('save-btn')?.addEventListener('click', () => {
-    const btn = getById('save-btn');
-    const originalText = btn.textContent;
-    btn.textContent = 'Saving...';
-    btn.disabled = true;
-    
-    saveAllSettings();
-    
-    setTimeout(() => {
-        btn.textContent = originalText;
-        btn.disabled = false;
-    }, 1000);
+  // Save
+  getById('save-btn')?.addEventListener('click', save);
+
+  // Reset
+  getById('reset-btn')?.addEventListener('click', () => {
+    if (confirm('reset all settings to defaults?')) postMessage('resetSettings');
   });
 
-  // Reset button
-  getById('reset-btn')?.addEventListener('click', () => {
-    if(confirm('Reset all settings to default?')) {
-        postMessage('resetSettings');
-    }
+  // Reveal / hide passwords
+  getById('reveal-btn')?.addEventListener('click', () => {
+    keysRevealed = !keysRevealed;
+    PROVIDERS.forEach(p => {
+      const input = getById(`key-${p}`);
+      if (input) input.type = keysRevealed ? 'text' : 'password';
+    });
+  });
+
+  // Keyboard shortcuts
+  document.addEventListener('keydown', (e) => {
+    const mod = e.metaKey || e.ctrlKey;
+    if (mod && e.key === 's') { e.preventDefault(); save(); }
+    if (mod && e.key === 'r') { e.preventDefault(); if (confirm('reset all settings to defaults?')) postMessage('resetSettings'); }
   });
 }
 
-function renderSettings() {
+function save() {
+  const btn = getById('save-btn');
+  if (btn) { btn.disabled = true; btn.textContent = 'saving…'; }
+
+  const newSettings = {
+    ...currentSettings,
+    defaultProvider:     getById('default-provider').value,
+    defaultDiagramType:  getById('default-type').value,
+    defaultColorPalette: getById('default-palette').value,
+    defaultComplexity:   getById('default-complexity').value,
+  };
+
+  const apiKeys = {};
+  PROVIDERS.forEach(p => {
+    const input = getById(`key-${p}`);
+    if (input && input.value) apiKeys[p] = input.value;
+  });
+
+  postMessage('saveSettings', { settings: newSettings, apiKeys });
+}
+
+function render() {
   if (!currentSettings) return;
 
-  // Update status text based on configured providers
-  Object.entries(currentProviders).forEach(([provider, configured]) => {
-    const statusEl = getById(`status-${provider}`);
-    if (statusEl) {
-        if (configured) {
-            statusEl.textContent = 'Configured';
-            statusEl.style.color = 'var(--color-success)'; // Green for configured
-        } else {
-            statusEl.textContent = 'Not Configured';
-            statusEl.style.color = 'var(--color-text-secondary)';
-        }
-    }
+  Object.entries(currentProviders || {}).forEach(([provider, configured]) => {
+    if (configured) setStatus(provider, 'ok', 'configured');
+    else            setStatus(provider, '',   'unset');
   });
 
-  // General Settings
-  setSelectValue('default-provider', currentSettings.defaultProvider);
-  setSelectValue('default-type', currentSettings.defaultDiagramType);
-  setSelectValue('default-palette', currentSettings.defaultColorPalette);
-  setSelectValue('default-complexity', currentSettings.defaultComplexity);
+  setSelect('default-provider',   currentSettings.defaultProvider);
+  setSelect('default-type',       currentSettings.defaultDiagramType);
+  setSelect('default-palette',    currentSettings.defaultColorPalette);
+  setSelect('default-complexity', currentSettings.defaultComplexity);
 }
 
-function setSelectValue(id, value) {
+function setStatus(provider, state, text) {
+  const el = getById(`status-${provider}`);
+  if (!el) return;
+  el.className = 'status' + (state ? ' ' + state : '');
+  el.textContent = text;
+}
+
+function setSelect(id, value) {
   const el = getById(id);
   if (el) el.value = value || '';
-}
-
-function saveAllSettings() {
-  const newSettings = { ...currentSettings };
-  
-  // Get values from form
-  newSettings.defaultProvider = getById('default-provider').value;
-  newSettings.defaultDiagramType = getById('default-type').value;
-  newSettings.defaultColorPalette = getById('default-palette').value;
-  newSettings.defaultComplexity = getById('default-complexity').value;
-
-  // Get API keys
-  const apiKeys = {};
-  const providers = ['openai', 'anthropic', 'google', 'flowcraft'];
-  
-  providers.forEach(provider => {
-    const input = getById(`key-${provider}`);
-    // Only update if value is present (empty fields might mean "keep existing" or "clear" depends on backend)
-    // Assuming backend handles empty string as "don't update" or we send all. 
-    // If user allows clearing, we might need a clearer UI for "Clear Key".
-    // For now, send if value exists.
-    if (input && input.value) {
-      apiKeys[provider] = input.value;
-    }
-  });
-
-  postMessage('saveSettings', {
-    settings: newSettings,
-    apiKeys
-  });
 }

--- a/media/webview/shared/styles/components.css
+++ b/media/webview/shared/styles/components.css
@@ -1,512 +1,237 @@
 /**
- * FlowCraft Reusable Components
- * Apple-inspired component library
+ * Flat, TUI-ish components. Sharp corners, monospace everywhere,
+ * focus shown with a hard 1px border rather than shadows or glows.
  */
 
-/* Buttons */
+/* ——————— Button ——————— */
 .btn {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: var(--spacing-sm);
-  padding: var(--spacing-sm) var(--spacing-lg);
-  font-family: var(--font-family-body);
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-semibold);
-  border-radius: var(--radius-md);
-  border: none;
+  gap: var(--fc-sp-3);
+  padding: var(--fc-sp-3) var(--fc-sp-5);
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs);
+  color: var(--fc-fg);
+  background: transparent;
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius-1);
   cursor: pointer;
-  transition: all var(--transition-normal);
+  transition: background var(--fc-t-fast), border-color var(--fc-t-fast), color var(--fc-t-fast);
   white-space: nowrap;
   user-select: none;
+  line-height: 1.2;
 }
-
 .btn:hover {
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-md);
+  background: var(--fc-surface);
+  border-color: var(--fc-fg-muted);
 }
-
-.btn:active {
-  transform: translateY(0);
-  box-shadow: var(--shadow-sm);
-}
+.btn:active { transform: translateY(1px); }
 
 .btn-primary {
-  background-color: var(--color-primary);
-  color: var(--color-text-inverse);
-  box-shadow: var(--shadow-sm);
+  color: var(--vscode-button-foreground);
+  background: var(--vscode-button-background);
+  border-color: var(--vscode-button-background);
 }
-
 .btn-primary:hover {
-  background-color: color-mix(in srgb, var(--color-primary) 85%, black);
+  background: var(--vscode-button-hoverBackground, var(--vscode-button-background));
+  border-color: var(--vscode-button-hoverBackground, var(--vscode-button-background));
 }
 
-.btn-secondary {
-  background-color: transparent;
-  color: var(--color-primary);
-  border: 1px solid var(--color-border);
-}
+.btn-ghost { border-color: transparent; color: var(--fc-fg-muted); }
+.btn-ghost:hover { color: var(--fc-fg); background: var(--fc-surface); border-color: var(--fc-border); }
 
-.btn-secondary:hover {
-  background-color: var(--color-surface);
-  border-color: var(--color-primary);
-}
-
-.btn-success {
-  background-color: var(--color-success);
-  color: var(--color-text-inverse);
-}
-
-.btn-danger {
-  background-color: var(--color-error);
-  color: var(--color-text-inverse);
-}
-
-.btn-small {
-  padding: 4px 12px;
-  font-size: var(--font-size-sm);
-}
-
-.btn-large {
-  padding: var(--spacing-md) var(--spacing-xl);
-  font-size: var(--font-size-md);
-}
+.btn-sm { padding: var(--fc-sp-2) var(--fc-sp-4); font-size: var(--fc-fs-sm); }
 
 .btn-icon {
-  padding: var(--spacing-sm);
-  border-radius: var(--radius-md);
-  background-color: transparent;
-  color: var(--color-text-primary);
-  border: none;
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 24px; height: 24px; padding: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--fc-fg-muted);
   cursor: pointer;
-  transition: all var(--transition-normal);
+  border-radius: var(--fc-radius-1);
+  transition: color var(--fc-t-fast), background var(--fc-t-fast), border-color var(--fc-t-fast);
+}
+.btn-icon:hover { color: var(--fc-fg); background: var(--fc-surface); border-color: var(--fc-border); }
+.btn-icon i { font-size: 14px; }
+
+/* ——————— Keyboard hint ——————— */
+kbd, .kbd {
+  display: inline-block;
+  padding: 1px 5px;
+  font-family: var(--fc-font-mono);
+  font-size: 10px;
+  line-height: 1.4;
+  color: var(--fc-fg-muted);
+  background: var(--fc-surface);
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius-1);
+  white-space: nowrap;
 }
 
-.btn-icon:hover {
-  background-color: var(--color-surface);
-}
-
-/* Cards */
-.card {
-  background-color: var(--color-surface);
-  border-radius: var(--radius-lg);
-  padding: var(--spacing-lg);
-  border: 1px solid var(--color-border);
-  transition: all var(--transition-normal);
-}
-
-.card-hover {
-  cursor: pointer;
-}
-
-.card-hover:hover {
-  transform: scale(1.02);
-  box-shadow: var(--shadow-md);
-  border-color: var(--color-primary);
-}
-
-.card-title {
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
-  margin-bottom: var(--spacing-sm);
-}
-
-.card-description {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-  line-height: var(--line-height-relaxed);
-}
-
-/* Action Cards */
-.action-card {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  gap: var(--spacing-sm);
-  padding: var(--spacing-lg);
-  background-color: var(--color-surface);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--color-border);
-  cursor: pointer;
-  transition: all var(--transition-normal);
-  min-height: 120px;
-}
-
-.action-card:hover {
-  transform: scale(1.02);
-  box-shadow: var(--shadow-md);
-  border-color: var(--color-primary);
-}
-
-.action-card-icon {
-  font-size: 32px;
-  color: var(--color-primary);
-}
-
-.action-card-title {
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
-}
-
-.action-card-subtitle {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-secondary);
-}
-
-/* Input Fields */
+/* ——————— Input ——————— */
 .input {
   width: 100%;
-  padding: 10px 12px;
-  font-family: var(--font-family-body);
-  font-size: var(--font-size-base);
-  color: var(--color-text-primary);
-  background-color: var(--color-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  transition: all var(--transition-normal);
+  padding: var(--fc-sp-3) var(--fc-sp-4);
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs);
+  color: var(--vscode-input-foreground, var(--fc-fg));
+  background: var(--vscode-input-background, var(--fc-surface));
+  border: 1px solid var(--vscode-input-border, var(--fc-border));
+  border-radius: var(--fc-radius-1);
+  transition: border-color var(--fc-t-fast);
 }
-
 .input:focus {
   outline: none;
-  border-color: var(--color-primary);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 15%, transparent);
+  border-color: var(--fc-border-hi);
+}
+.input::placeholder { color: var(--fc-fg-dim); font-style: normal; }
+
+select.input {
+  cursor: pointer;
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--fc-fg-muted) 50%),
+    linear-gradient(135deg, var(--fc-fg-muted) 50%, transparent 50%);
+  background-position:
+    calc(100% - 14px) 50%,
+    calc(100% - 9px) 50%;
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+  padding-right: 26px;
+  appearance: none;
+  -webkit-appearance: none;
 }
 
-.input::placeholder {
-  color: var(--color-text-secondary);
-}
-
-.input:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.textarea {
-  min-height: 120px;
-  font-family: var(--font-family-mono);
-  resize: vertical;
-}
-
-/* Form Groups */
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-sm);
-  margin-bottom: var(--spacing-md);
-}
-
-.form-label {
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-medium);
-  color: var(--color-text-primary);
-}
-
-.form-helper {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-}
-
-.form-error {
-  font-size: var(--font-size-sm);
-  color: var(--color-error);
-}
-
-/* Badges */
-.badge {
+/* ——————— Status badge (inline) ——————— */
+.tag {
   display: inline-flex;
   align-items: center;
-  padding: 2px 8px;
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-semibold);
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--color-border);
-  background-color: var(--color-surface);
-  color: var(--color-text-primary);
+  gap: 4px;
+  padding: 1px 6px;
+  font-family: var(--fc-font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fc-fg-muted);
+  background: transparent;
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius-1);
+  line-height: 1.4;
 }
+.tag-ok   { color: var(--fc-ok);   border-color: color-mix(in srgb, var(--fc-ok)   35%, transparent); }
+.tag-warn { color: var(--fc-warn); border-color: color-mix(in srgb, var(--fc-warn) 35%, transparent); }
+.tag-err  { color: var(--fc-err);  border-color: color-mix(in srgb, var(--fc-err)  35%, transparent); }
+.tag-pro  { color: var(--fc-accent); border-color: color-mix(in srgb, var(--fc-accent) 35%, transparent); }
 
-.badge-primary {
-  background-color: color-mix(in srgb, var(--color-primary) 15%, transparent);
-  color: var(--color-primary);
-  border-color: color-mix(in srgb, var(--color-primary) 30%, transparent);
-}
-
-.badge-success {
-  background-color: color-mix(in srgb, var(--color-success) 15%, transparent);
-  color: var(--color-success);
-  border-color: color-mix(in srgb, var(--color-success) 30%, transparent);
-}
-
-.badge-warning {
-  background-color: color-mix(in srgb, var(--color-warning) 15%, transparent);
-  color: var(--color-warning);
-  border-color: color-mix(in srgb, var(--color-warning) 30%, transparent);
-}
-
-.badge-error {
-  background-color: color-mix(in srgb, var(--color-error) 15%, transparent);
-  color: var(--color-error);
-  border-color: color-mix(in srgb, var(--color-error) 30%, transparent);
-}
-
-/* Progress Bar */
-.progress-bar {
-  width: 100%;
-  height: 4px;
-  background-color: var(--color-surface);
-  border-radius: var(--radius-sm);
-  overflow: hidden;
-}
-
-.progress-bar-fill {
-  height: 100%;
-  background-color: var(--color-primary);
-  border-radius: var(--radius-sm);
-  transition: width var(--transition-slow);
-}
-
-.progress-bar-fill.indeterminate {
-  width: 30%;
-  animation: indeterminate 1.5s ease-in-out infinite;
-}
-
-/* Spinner */
-.spinner {
-  width: 20px;
-  height: 20px;
-  border: 2px solid var(--color-border);
-  border-top-color: var(--color-primary);
+.tag .dot {
+  display: inline-block;
+  width: 6px; height: 6px;
   border-radius: 50%;
-  animation: spin 0.6s linear infinite;
+  background: currentColor;
 }
 
-.spinner-large {
-  width: 40px;
-  height: 40px;
-  border-width: 3px;
-}
-
-/* Tabs */
-.tabs {
-  display: flex;
-  gap: var(--spacing-sm);
-  border-bottom: 1px solid var(--color-border);
-  margin-bottom: var(--spacing-lg);
-}
-
-.tab {
-  padding: var(--spacing-sm) var(--spacing-md);
-  background-color: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  color: var(--color-text-secondary);
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-medium);
-  cursor: pointer;
-  transition: all var(--transition-normal);
-}
-
-.tab:hover {
-  color: var(--color-text-primary);
-}
-
-.tab.active {
-  color: var(--color-primary);
-  border-bottom-color: var(--color-primary);
-}
-
-/* Divider */
-.divider {
-  height: 1px;
-  background-color: var(--color-divider);
-  margin: var(--spacing-lg) 0;
-}
-
-/* Grid Layouts */
-.grid {
-  display: grid;
-  gap: var(--spacing-md);
-}
-
-.grid-2 {
-  grid-template-columns: repeat(2, 1fr);
-}
-
-.grid-3 {
-  grid-template-columns: repeat(3, 1fr);
-}
-
-.grid-4 {
-  grid-template-columns: repeat(4, 1fr);
-}
-
-@media (max-width: 768px) {
-  .grid-2, .grid-3, .grid-4 {
-    grid-template-columns: 1fr;
-  }
-}
-
-/* List */
-.list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.list-item {
-  padding: var(--spacing-md);
-  background-color: var(--color-surface);
-  border-radius: var(--radius-md);
-  margin-bottom: var(--spacing-sm);
-  transition: all var(--transition-normal);
-}
-
-.list-item:hover {
-  background-color: var(--color-surface-elevated);
-  transform: translateX(4px);
-}
-
-/* Empty State */
-.empty-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: var(--spacing-3xl) var(--spacing-xl);
-  text-align: center;
-}
-
-.empty-state-icon {
-  font-size: 64px;
-  color: var(--color-text-tertiary);
-  margin-bottom: var(--spacing-lg);
-  opacity: 0.5;
-}
-
-.empty-state-title {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
-  margin-bottom: var(--spacing-sm);
-}
-
-.empty-state-description {
-  font-size: var(--font-size-base);
-  color: var(--color-text-secondary);
-  max-width: 400px;
-  margin-bottom: var(--spacing-lg);
-}
-
-/* Toast/Alert */
-.toast {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-md);
-  padding: var(--spacing-md) var(--spacing-lg);
-  background-color: var(--color-surface-elevated);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-lg);
-  border-left: 4px solid var(--color-primary);
-}
-
-.toast-success {
-  border-left-color: var(--color-success);
-}
-
-.toast-warning {
-  border-left-color: var(--color-warning);
-}
-
-.toast-error {
-  border-left-color: var(--color-error);
-}
-
-.toast-icon {
-  flex-shrink: 0;
-  font-size: 20px;
-}
-
-.toast-content {
-  flex: 1;
-}
-
-.toast-title {
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
-  margin-bottom: 2px;
-}
-
-.toast-message {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-}
-
-/* Modal */
-.modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(4px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: var(--z-modal-backdrop);
-}
-
-.modal {
-  background-color: var(--color-bg);
-  border-radius: var(--radius-xl);
-  padding: var(--spacing-xl);
-  max-width: 600px;
-  width: 90%;
-  max-height: 80vh;
-  overflow-y: auto;
-  box-shadow: var(--shadow-xl);
-  z-index: var(--z-modal);
-}
-
-.modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: var(--spacing-lg);
-}
-
-.modal-title {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
-}
-
-.modal-body {
-  margin-bottom: var(--spacing-lg);
-}
-
-.modal-footer {
-  display: flex;
-  gap: var(--spacing-sm);
-  justify-content: flex-end;
-}
-
-/* Utility Classes */
-.hidden {
-  display: none;
-}
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
+/* ——————— Progress ——————— */
+.progress {
+  position: relative;
+  height: 4px;
+  background: var(--fc-surface);
+  border: 1px solid var(--fc-border);
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  border-radius: var(--fc-radius-1);
+}
+.progress > .fill {
+  position: absolute; inset: 0 auto 0 0;
+  width: 0%;
+  background: var(--fc-accent);
+  transition: width var(--fc-t);
+}
+.progress > .fill.warn { background: var(--fc-warn); }
+.progress > .fill.err  { background: var(--fc-err); }
+
+/* ——————— Action tile — like a command in a menu ——————— */
+.tile {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: var(--fc-sp-4);
+  padding: var(--fc-sp-4) var(--fc-sp-5);
+  background: transparent;
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius-1);
+  cursor: pointer;
+  font-family: var(--fc-font-mono);
+  color: var(--fc-fg);
+  text-align: left;
+  width: 100%;
+  transition: background var(--fc-t-fast), border-color var(--fc-t-fast), transform var(--fc-t-fast);
+}
+.tile:hover {
+  background: var(--fc-surface);
+  border-color: var(--fc-fg-muted);
+}
+.tile:hover .tile-num { color: var(--fc-accent); }
+.tile:active { transform: translateX(1px); }
+
+.tile-num {
+  width: 20px; height: 20px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: var(--fc-fs-sm);
+  color: var(--fc-fg-muted);
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius-1);
+  transition: color var(--fc-t-fast);
+}
+
+.tile-body { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.tile-title {
+  font-size: var(--fc-fs);
+  color: var(--fc-fg);
+}
+.tile-title::before {
+  content: "$ ";
+  color: var(--fc-fg-dim);
+}
+.tile-desc {
+  font-size: var(--fc-fs-sm);
+  color: var(--fc-fg-muted);
   white-space: nowrap;
-  border-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ——————— Row (settings list) ——————— */
+.row {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--fc-sp-3);
+  padding: var(--fc-sp-5) 0;
+  border-bottom: 1px dashed var(--fc-border);
+}
+.row:last-child { border-bottom: none; }
+
+.row-head {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: var(--fc-sp-4);
+}
+.row-key {
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs);
+  color: var(--fc-fg);
+}
+.row-key .prefix { color: var(--fc-fg-dim); }
+.row-hint {
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs-sm);
+  color: var(--fc-fg-muted);
+}
+
+.row-control { display: flex; gap: var(--fc-sp-3); align-items: center; }
+.row-control .input { flex: 1; }
+
+.row-foot {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: var(--fc-sp-4);
+  font-size: var(--fc-fs-sm);
+  color: var(--fc-fg-muted);
+  min-height: 16px;
 }

--- a/media/webview/shared/styles/theme.css
+++ b/media/webview/shared/styles/theme.css
@@ -1,335 +1,173 @@
 /**
- * FlowCraft Theme System - Apple-inspired Design
- * Variables for consistent styling across all webviews
+ * FlowCraft — terminal/IDE-native theme.
+ * Uses VS Code's own CSS variables so the extension inherits the user's
+ * editor theme exactly. No custom palettes; accents are derived from
+ * VS Code's semantic tokens.
  */
 
 :root {
-  /* Light Theme Colors - Apple Minimalist Black/White */
-  --color-primary: #000000;
-  --color-secondary: #666666;
-  --color-success: #2c2c2c; /* Dark grey instead of green */
-  --color-warning: #666666;
-  --color-error: #000000; /* Use iconography for error, keep text black or use pattern */
-  --color-info: #000000;
+  /* Surfaces — pulled directly from the host theme */
+  --fc-bg:           var(--vscode-sideBar-background, var(--vscode-editor-background));
+  --fc-bg-alt:       var(--vscode-editor-background);
+  --fc-surface:      var(--vscode-editorWidget-background, var(--vscode-sideBar-background));
+  --fc-surface-hi:   var(--vscode-input-background);
+  --fc-border:       var(--vscode-panel-border, var(--vscode-editorWidget-border, rgba(128,128,128,0.25)));
+  --fc-border-hi:    var(--vscode-focusBorder);
 
-  --color-bg: #F5F5F7; /* Apple System Grey 6 (Light) */
-  --color-surface: #FFFFFF;
-  --color-surface-elevated: #FFFFFF;
-  --color-border: #E5E5EA; /* Apple System Grey 4 */
-  --color-divider: #C6C6C8; /* Apple System Grey 3 */
+  /* Text — derived from the current foreground so every theme stays legible */
+  --fc-fg:           var(--vscode-sideBar-foreground, var(--vscode-foreground));
+  --fc-fg-muted:     color-mix(in srgb, var(--fc-fg) 62%, transparent);
+  --fc-fg-dim:       color-mix(in srgb, var(--fc-fg) 42%, transparent);
 
-  --color-text-primary: #000000;
-  --color-text-secondary: #86868b;
-  --color-text-tertiary: #d2d2d7;
-  --color-text-inverse: #FFFFFF;
+  /* Accents — semantic tokens straight from the theme */
+  --fc-accent:       var(--vscode-textLink-foreground);
+  --fc-accent-hi:    var(--vscode-textLink-activeForeground, var(--vscode-textLink-foreground));
+  --fc-ok:           var(--vscode-testing-iconPassed, var(--vscode-charts-green, #3fb950));
+  --fc-warn:         var(--vscode-editorWarning-foreground, var(--vscode-charts-yellow, #d29922));
+  --fc-err:          var(--vscode-editorError-foreground, var(--vscode-charts-red, #f85149));
 
-  /* Spacing System */
-  --spacing-xs: 4px;
-  --spacing-sm: 8px;
-  --spacing-md: 14px; /* Slightly larger for airy feel */
-  --spacing-lg: 20px;
-  --spacing-xl: 32px;
-  --spacing-2xl: 48px;
-  --spacing-3xl: 64px;
+  /* Typography — editor font so the panel feels like part of the IDE */
+  --fc-font-mono:    var(--vscode-editor-font-family, "SF Mono", "JetBrains Mono", "Fira Code", Menlo, Consolas, monospace);
+  --fc-font-ui:      var(--vscode-font-family);
+  --fc-fs-editor:    var(--vscode-editor-font-size, 13px);
 
-  /* Typography */
-  --font-family-display: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  --font-family-body: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  --font-family-mono: "SF Mono", "Monaco", "Consolas", "Courier New", monospace;
+  --fc-fs-xs:  10px;
+  --fc-fs-sm:  11px;
+  --fc-fs:     12px;
+  --fc-fs-md:  13px;
+  --fc-fs-lg:  15px;
 
-  --font-size-xs: 11px;
-  --font-size-sm: 12px;
-  --font-size-base: 13px;
-  --font-size-md: 15px;
-  --font-size-lg: 17px;
-  --font-size-xl: 22px;
-  --font-size-2xl: 34px; /* Larger titles */
+  /* Space — dense, like a terminal pane */
+  --fc-sp-1:   2px;
+  --fc-sp-2:   4px;
+  --fc-sp-3:   6px;
+  --fc-sp-4:   8px;
+  --fc-sp-5:   12px;
+  --fc-sp-6:   16px;
+  --fc-sp-7:   24px;
+  --fc-sp-8:   32px;
 
-  --font-weight-regular: 400;
-  --font-weight-medium: 500;
-  --font-weight-semibold: 600;
-  --font-weight-bold: 700;
+  /* Corners — sharp */
+  --fc-radius-0: 0;
+  --fc-radius-1: 2px;
+  --fc-radius-2: 3px;
 
-  --line-height-tight: 1.2;
-  --line-height-normal: 1.5;
-  --line-height-relaxed: 1.7;
-
-  /* Border Radius */
-  --radius-sm: 6px;
-  --radius-md: 10px;
-  --radius-lg: 16px;
-  --radius-xl: 20px;
-  --radius-full: 9999px;
-
-  /* Shadows - Minimal */
-  --shadow-xs: 0 1px 1px rgba(0, 0, 0, 0.03);
-  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.04);
-  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.06);
-  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.08);
-  --shadow-xl: 0 16px 32px rgba(0, 0, 0, 0.1);
-
-  /* Transitions */
-  --transition-fast: 150ms ease;
-  --transition-normal: 250ms ease;
-  --transition-slow: 350ms ease;
-  --transition-very-slow: 500ms ease;
-
-  /* Z-Index */
-  --z-dropdown: 1000;
-  --z-sticky: 1020;
-  --z-fixed: 1030;
-  --z-modal-backdrop: 1040;
-  --z-modal: 1050;
-  --z-popover: 1060;
-  --z-tooltip: 1070;
+  /* Motion */
+  --fc-t-fast:   90ms ease-out;
+  --fc-t:        140ms ease-out;
 }
 
-/* Dark Theme */
-body[data-vscode-theme-kind="vscode-dark"],
-body[data-vscode-theme-kind="vscode-high-contrast"] {
-  --color-primary: #FFFFFF;
-  --color-secondary: #98989D;
-  --color-success: #FFFFFF;
-  --color-warning: #98989D;
-  --color-error: #FFFFFF;
-  --color-info: #FFFFFF;
+/* Reset */
+* { box-sizing: border-box; margin: 0; padding: 0; }
 
-  --color-bg: #000000;
-  --color-surface: #1C1C1E;
-  --color-surface-elevated: #2C2C2E;
-  --color-border: #38383A;
-  --color-divider: #48484A;
-
-  --color-text-primary: #FFFFFF;
-  --color-text-secondary: #8E8E93;
-  --color-text-tertiary: #48484A;
-  --color-text-inverse: #000000;
-
-  /* Adjust shadows for dark theme */
-  --shadow-xs: 0 1px 1px rgba(0, 0, 0, 0.5);
-  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.5);
-  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.5);
-  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
-  --shadow-xl: 0 16px 32px rgba(0, 0, 0, 0.5);
-}
-
-/* Base Styles */
-* {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
-
-html {
-  font-size: 13px;
+html, body {
+  background: var(--fc-bg);
+  color: var(--fc-fg);
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs);
+  line-height: 1.55;
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  text-rendering: geometricPrecision;
 }
 
 body {
-  font-family: var(--font-family-body);
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-regular);
-  line-height: var(--line-height-normal);
-  color: var(--color-text-primary);
-  background-color: var(--color-bg);
+  /* Solid — scanline backgrounds read as banding on light themes */
 }
 
 /* Typography */
-h1, h2, h3, h4, h5, h6 {
-  font-family: var(--font-family-display);
-  font-weight: var(--font-weight-semibold);
-  line-height: var(--line-height-tight);
-  color: var(--color-text-primary);
-  margin: 0;
+h1, h2, h3, h4 {
+  font-family: var(--fc-font-mono);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--fc-fg);
 }
 
-h1 {
-  font-size: var(--font-size-2xl);
-  font-weight: var(--font-weight-bold);
-}
+h1 { font-size: var(--fc-fs-lg); text-transform: lowercase; }
+h2 { font-size: var(--fc-fs-md); }
+h3 { font-size: var(--fc-fs);    }
 
-h2 {
-  font-size: var(--font-size-xl);
-}
+p  { margin: 0; color: var(--fc-fg); }
 
-h3 {
-  font-size: var(--font-size-lg);
-}
-
-h4 {
-  font-size: var(--font-size-md);
-}
-
-p {
-  margin: 0;
-}
-
-/* Links */
 a {
-  color: var(--color-primary);
+  color: var(--fc-accent);
   text-decoration: none;
-  transition: opacity var(--transition-fast);
+  border-bottom: 1px dashed transparent;
+  transition: border-color var(--fc-t-fast);
+}
+a:hover, a:focus-visible {
+  border-bottom-color: var(--fc-accent);
+  outline: none;
 }
 
-a:hover {
-  opacity: 0.8;
+code, kbd, pre {
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs-sm);
 }
 
-a:active {
-  opacity: 0.6;
-}
-
-/* Code */
-code, pre {
-  font-family: var(--font-family-mono);
-  font-size: var(--font-size-sm);
-}
-
-code {
-  padding: 2px 4px;
-  background-color: var(--color-surface);
-  border-radius: var(--radius-sm);
-}
-
-pre {
-  padding: var(--spacing-md);
-  background-color: var(--color-surface);
-  border-radius: var(--radius-md);
-  overflow-x: auto;
-}
-
-pre code {
-  padding: 0;
-  background-color: transparent;
-}
-
-/* Scrollbar */
-::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
-}
-
-::-webkit-scrollbar-track {
-  background: var(--color-bg);
-}
-
+/* Scrollbar — thin, flat */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb {
-  background: var(--color-border);
-  border-radius: var(--radius-full);
+  background: var(--fc-border);
+  border-radius: 0;
 }
-
-::-webkit-scrollbar-thumb:hover {
-  background: var(--color-text-secondary);
-}
+::-webkit-scrollbar-thumb:hover { background: var(--fc-fg-muted); }
 
 /* Selection */
 ::selection {
-  background-color: var(--color-primary);
-  color: var(--color-text-inverse);
-  opacity: 0.3;
+  background: var(--vscode-editor-selectionBackground, var(--fc-accent));
+  color: var(--vscode-editor-selectionForeground, var(--fc-fg));
 }
 
 /* Focus */
 :focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
+  outline: 1px solid var(--fc-border-hi);
+  outline-offset: 1px;
 }
 
 /* Disabled */
-:disabled {
-  opacity: 0.5;
+:disabled, [disabled] {
+  opacity: 0.45;
   cursor: not-allowed;
 }
 
-/* Utility Classes */
-.text-primary {
-  color: var(--color-text-primary);
+/* ——————— Utility ——————— */
+.hidden { display: none !important; }
+
+.mono { font-family: var(--fc-font-mono); }
+.muted { color: var(--fc-fg-muted); }
+.dim   { color: var(--fc-fg-dim); }
+.ok    { color: var(--fc-ok); }
+.warn  { color: var(--fc-warn); }
+.err   { color: var(--fc-err); }
+
+.flex         { display: flex; }
+.col          { flex-direction: column; }
+.items-center { align-items: center; }
+.between      { justify-content: space-between; }
+.gap-1        { gap: var(--fc-sp-2); }
+.gap-2        { gap: var(--fc-sp-4); }
+.gap-3        { gap: var(--fc-sp-5); }
+
+/* Hairline rule, like a TUI box edge */
+.rule {
+  height: 1px;
+  background: var(--fc-border);
+  margin: var(--fc-sp-5) 0;
 }
 
-.text-secondary {
-  color: var(--color-text-secondary);
+/* Section marker: `// foo` style heading */
+.section-marker {
+  display: block;
+  font-size: var(--fc-fs-sm);
+  color: var(--fc-fg-muted);
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+  padding: var(--fc-sp-2) 0;
+  border-bottom: 1px dashed var(--fc-border);
+  margin-bottom: var(--fc-sp-4);
 }
-
-.text-tertiary {
-  color: var(--color-text-tertiary);
+.section-marker::before {
+  content: "// ";
+  color: var(--fc-fg-dim);
 }
-
-.text-success {
-  color: var(--color-success);
-}
-
-.text-warning {
-  color: var(--color-warning);
-}
-
-.text-error {
-  color: var(--color-error);
-}
-
-.bg-surface {
-  background-color: var(--color-surface);
-}
-
-.bg-elevated {
-  background-color: var(--color-surface-elevated);
-}
-
-/* Layout Utilities */
-.container {
-  width: 100%;
-  padding: var(--spacing-lg);
-}
-
-.flex {
-  display: flex;
-}
-
-.flex-col {
-  display: flex;
-  flex-direction: column;
-}
-
-.items-center {
-  align-items: center;
-}
-
-.justify-center {
-  justify-content: center;
-}
-
-.justify-between {
-  justify-content: space-between;
-}
-
-.gap-xs { gap: var(--spacing-xs); }
-.gap-sm { gap: var(--spacing-sm); }
-.gap-md { gap: var(--spacing-md); }
-.gap-lg { gap: var(--spacing-lg); }
-.gap-xl { gap: var(--spacing-xl); }
-
-/* Spacing Utilities */
-.p-xs { padding: var(--spacing-xs); }
-.p-sm { padding: var(--spacing-sm); }
-.p-md { padding: var(--spacing-md); }
-.p-lg { padding: var(--spacing-lg); }
-.p-xl { padding: var(--spacing-xl); }
-
-.m-xs { margin: var(--spacing-xs); }
-.m-sm { margin: var(--spacing-sm); }
-.m-md { margin: var(--spacing-md); }
-.m-lg { margin: var(--spacing-lg); }
-.m-xl { margin: var(--spacing-xl); }
-
-/* Border Radius Utilities */
-.rounded-sm { border-radius: var(--radius-sm); }
-.rounded-md { border-radius: var(--radius-md); }
-.rounded-lg { border-radius: var(--radius-lg); }
-.rounded-xl { border-radius: var(--radius-xl); }
-.rounded-full { border-radius: var(--radius-full); }
-
-/* Shadow Utilities */
-.shadow-sm { box-shadow: var(--shadow-sm); }
-.shadow-md { box-shadow: var(--shadow-md); }
-.shadow-lg { box-shadow: var(--shadow-lg); }
-.shadow-xl { box-shadow: var(--shadow-xl); }

--- a/media/webview/welcome/index.html
+++ b/media/webview/welcome/index.html
@@ -4,105 +4,111 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src {{cspSource}} 'unsafe-inline'; script-src 'nonce-{{nonce}}'; img-src {{cspSource}} https: data:;">
-    <title>FlowCraft Welcome</title>
-    
+    <title>FlowCraft</title>
+
     <link rel="stylesheet" href="{{themeCss}}">
     <link rel="stylesheet" href="{{componentsCss}}">
     <link rel="stylesheet" href="{{welcomeCss}}">
     <link rel="stylesheet" href="{{codiconCss}}">
 </head>
 <body>
-    <div class="welcome-container">
-        <div class="header">
-            <div class="logo-container">
-                <!-- Placeholder for logo, could be an SVG or img -->
-                <svg class="logo animate-bounce" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
-                    <defs>
-                        <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
-                            <stop offset="0%" style="stop-color:#007AFF;stop-opacity:1" />
-                            <stop offset="100%" style="stop-color:#5856D6;stop-opacity:1" />
-                        </linearGradient>
-                    </defs>
-                    <rect x="32" y="32" width="80" height="80" rx="16" fill="url(#grad)" />
-                    <circle cx="184" cy="72" r="40" fill="url(#grad)" opacity="0.8" />
-                    <polygon points="128,144 48,224 208,224" fill="url(#grad)" opacity="0.9" />
-                </svg>
-            </div>
-            <h1>FlowCraft</h1>
-            <p class="subtitle">AI-Powered Diagram Generator</p>
-        </div>
+    <main class="wc">
 
-        <div class="usage-section">
-            <div class="usage-header">
-                <span class="usage-title">Subscription</span>
-                <div id="subscription-badge">
-                    <span class="badge badge-secondary">Free</span>
-                </div>
+        <header class="wc-head">
+            <div class="wc-prompt">
+                <span class="wc-prompt-user">flowcraft</span><span class="wc-prompt-sep">@</span><span class="wc-prompt-host">vscode</span>
+                <span class="wc-prompt-path">~/diagrams</span>
+                <span class="wc-prompt-caret">$</span>
             </div>
-            <div class="progress-bar" id="usage-progress">
-                <div class="progress-bar-fill" id="usage-fill" style="width: 0%"></div>
-            </div>
-            <div class="usage-header" style="margin-top: 8px; margin-bottom: 0;">
-                <span class="usage-limit" id="usage-text">Loading usage...</span>
-                <span class="usage-limit" id="usage-limit"></span>
-            </div>
-        </div>
+            <div class="wc-version muted">v2.1.0</div>
+        </header>
 
-        <div class="action-grid">
-            <div class="action-card" id="action-diagram">
-                <div class="action-card-icon">
-                    <i class="codicon codicon-graph"></i>
-                </div>
-                <div class="action-card-title">Diagram</div>
-                <div class="action-card-subtitle">Flowchart, Sequence...</div>
+        <section class="wc-status" aria-label="subscription status">
+            <div class="wc-status-row">
+                <span class="wc-status-label">plan</span>
+                <span id="subscription-badge" class="tag"><span class="dot"></span>free</span>
             </div>
-            
-            <div class="action-card" id="action-infographic">
-                <div class="action-card-icon">
-                    <i class="codicon codicon-dashboard"></i>
-                </div>
-                <div class="action-card-title">Infographic</div>
-                <div class="action-card-subtitle">Visual Data</div>
+            <div class="progress" id="usage-progress" aria-hidden="false">
+                <div class="fill" id="usage-fill" style="width: 0%"></div>
             </div>
-
-            <div class="action-card" id="action-image">
-                <div class="action-card-icon">
-                    <i class="codicon codicon-file-media"></i>
-                </div>
-                <div class="action-card-title">Image</div>
-                <div class="action-card-subtitle">AI Illustration</div>
+            <div class="wc-status-row wc-status-foot">
+                <span id="usage-text" class="mono muted">—</span>
+                <span id="usage-limit" class="mono muted"></span>
             </div>
+        </section>
 
-            <div class="action-card" id="action-history">
-                <div class="action-card-icon">
-                    <i class="codicon codicon-history"></i>
-                </div>
-                <div class="action-card-title">History</div>
-                <div class="action-card-subtitle">Past Visuals</div>
-            </div>
-        </div>
+        <span class="section-marker">actions</span>
 
-        <div class="divider"></div>
+        <nav class="wc-actions" aria-label="commands">
+            <button class="tile" id="action-diagram" data-key="1">
+                <span class="tile-num">1</span>
+                <span class="tile-body">
+                    <span class="tile-title">generate diagram</span>
+                    <span class="tile-desc">flowchart · sequence · class · er · …</span>
+                </span>
+                <span class="kbd">⌘⇧D</span>
+            </button>
 
-        <div class="quick-links">
-            <a href="#" class="link-item" id="link-settings">
-                <i class="codicon codicon-settings-gear link-icon"></i>
-                <span>Settings & API Keys</span>
-            </a>
-            <a href="https://flowcraft.app/docs" class="link-item">
-                <i class="codicon codicon-book link-icon"></i>
-                <span>Documentation</span>
-            </a>
-            <a href="https://github.com/flowcraft/vscode/issues" class="link-item">
-                <i class="codicon codicon-github-action link-icon"></i>
-                <span>Report Issue</span>
-            </a>
-        </div>
+            <button class="tile" id="action-selection" data-key="2">
+                <span class="tile-num">2</span>
+                <span class="tile-body">
+                    <span class="tile-title">from selection</span>
+                    <span class="tile-desc">use the highlighted text in the editor</span>
+                </span>
+                <span class="kbd">⌘⇧G</span>
+            </button>
 
-        <div class="footer">
-            <p>v2.0.0 • FlowCraft Inc.</p>
-        </div>
-    </div>
+            <button class="tile" id="action-infographic" data-key="3">
+                <span class="tile-num">3</span>
+                <span class="tile-body">
+                    <span class="tile-title">infographic <span class="tag">soon</span></span>
+                    <span class="tile-desc">visual data summary</span>
+                </span>
+                <span class="kbd">—</span>
+            </button>
+
+            <button class="tile" id="action-image" data-key="4">
+                <span class="tile-num">4</span>
+                <span class="tile-body">
+                    <span class="tile-title">illustration <span class="tag">soon</span></span>
+                    <span class="tile-desc">ai-rendered image</span>
+                </span>
+                <span class="kbd">—</span>
+            </button>
+
+            <button class="tile" id="action-history" data-key="5">
+                <span class="tile-num">5</span>
+                <span class="tile-body">
+                    <span class="tile-title">history</span>
+                    <span class="tile-desc">previously generated diagrams</span>
+                </span>
+                <span class="kbd">⌘H</span>
+            </button>
+        </nav>
+
+        <span class="section-marker">shortcuts</span>
+
+        <ul class="wc-links">
+            <li><a href="#" id="link-settings" class="wc-link">
+                <span class="wc-link-caret">›</span> settings &amp; api keys
+                <span class="kbd">⌘,</span>
+            </a></li>
+            <li><a href="https://flowcraft.app/docs" class="wc-link">
+                <span class="wc-link-caret">›</span> docs
+                <span class="muted">flowcraft.app/docs</span>
+            </a></li>
+            <li><a href="https://github.com/flowcraft/vscode/issues" class="wc-link">
+                <span class="wc-link-caret">›</span> report issue
+                <span class="muted">github</span>
+            </a></li>
+        </ul>
+
+        <footer class="wc-foot">
+            <span class="wc-foot-cell"><span class="dim">STATUS</span> <span id="foot-status" class="ok">ready</span></span>
+            <span class="wc-foot-cell"><span class="dim">MODE</span> <span id="foot-mode">byok</span></span>
+            <span class="wc-foot-cell"><span class="dim">TIP</span> press <kbd>1</kbd>–<kbd>5</kbd> or <kbd>⌘⇧P</kbd> → flowcraft</span>
+        </footer>
+    </main>
 
     <script type="module" nonce="{{nonce}}" src="{{welcomeJs}}"></script>
 </body>

--- a/media/webview/welcome/welcome.css
+++ b/media/webview/welcome/welcome.css
@@ -1,110 +1,139 @@
-/* Welcome View Specific Styles */
+/* Welcome — terminal-pane layout */
 
-body {
-  padding: 0;
-  overflow-x: hidden;
-}
+body { padding: 0; overflow-x: hidden; }
 
-.welcome-container {
-  padding: var(--spacing-lg);
-  max-width: 100%;
-}
-
-.header {
-  margin-bottom: var(--spacing-xl);
-  text-align: center;
-}
-
-.logo {
-  width: 64px;
-  height: 64px;
-  margin-bottom: var(--spacing-md);
-}
-
-.subtitle {
-  font-size: var(--font-size-md);
-  color: var(--color-text-secondary);
-  margin-top: var(--spacing-xs);
-}
-
-.action-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: var(--spacing-md);
-  margin-bottom: var(--spacing-xl);
-}
-
-.usage-section {
-  background-color: var(--color-surface);
-  border-radius: var(--radius-lg);
-  padding: var(--spacing-lg);
-  margin-bottom: var(--spacing-xl);
-  border: 1px solid var(--color-border);
-}
-
-.usage-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: var(--spacing-md);
-}
-
-.usage-title {
-  font-weight: var(--font-weight-semibold);
-  font-size: var(--font-size-md);
-}
-
-.usage-limit {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-}
-
-.quick-links {
+.wc {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-sm);
+  gap: var(--fc-sp-6);
+  padding: var(--fc-sp-5);
+  min-height: 100vh;
 }
 
-.link-item {
+/* Prompt line ——————————————————————————— */
+.wc-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--fc-sp-4);
+  padding-bottom: var(--fc-sp-4);
+  border-bottom: 1px dashed var(--fc-border);
+}
+.wc-prompt {
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs-md);
+  color: var(--fc-fg);
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.wc-prompt-user { color: var(--fc-accent); }
+.wc-prompt-sep  { color: var(--fc-fg-dim); }
+.wc-prompt-host { color: var(--fc-fg-muted); }
+.wc-prompt-path { color: var(--fc-fg-muted); margin-left: var(--fc-sp-3); }
+.wc-prompt-caret {
+  color: var(--fc-accent);
+  margin-left: var(--fc-sp-3);
+  animation: wc-blink 1.1s steps(1) infinite;
+}
+@keyframes wc-blink { 50% { opacity: 0; } }
+
+.wc-version {
+  font-size: var(--fc-fs-sm);
+  font-family: var(--fc-font-mono);
+}
+
+/* Status block ——————————————————————————— */
+.wc-status {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fc-sp-3);
+  padding: var(--fc-sp-4) var(--fc-sp-5);
+  background: var(--fc-surface);
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius-1);
+}
+.wc-status-row {
   display: flex;
   align-items: center;
-  gap: var(--spacing-sm);
-  padding: var(--spacing-sm) var(--spacing-md);
-  border-radius: var(--radius-md);
-  color: var(--color-text-primary);
-  transition: background-color var(--transition-fast);
+  justify-content: space-between;
+  gap: var(--fc-sp-4);
+}
+.wc-status-label {
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs-sm);
+  color: var(--fc-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.wc-status-foot { font-size: var(--fc-fs-sm); }
+
+/* Actions ——————————————————————————— */
+.wc-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fc-sp-3);
 }
 
-.link-item:hover {
-  background-color: var(--color-surface);
-  text-decoration: none;
+/* Links list ——————————————————————————— */
+.wc-links {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--fc-sp-1);
+}
+.wc-link {
+  display: flex;
+  align-items: center;
+  gap: var(--fc-sp-3);
+  padding: var(--fc-sp-2) var(--fc-sp-3);
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs);
+  color: var(--fc-fg);
+  border: 1px solid transparent;
+  border-radius: var(--fc-radius-1);
+}
+.wc-link:hover {
+  background: var(--fc-surface);
+  border-color: var(--fc-border);
+  border-bottom-color: var(--fc-border); /* override anchor dashed underline */
+}
+.wc-link-caret { color: var(--fc-fg-dim); }
+.wc-link .kbd, .wc-link .muted { margin-left: auto; }
+
+/* Status line (terminal footer) ——————————————————— */
+.wc-foot {
+  margin-top: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--fc-sp-5);
+  padding: var(--fc-sp-3) var(--fc-sp-4);
+  font-family: var(--fc-font-mono);
+  font-size: 10px;
+  color: var(--fc-fg-muted);
+  background: var(--fc-surface);
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius-1);
+  letter-spacing: 0.04em;
+}
+.wc-foot .dim { color: var(--fc-fg-dim); margin-right: 4px; }
+.wc-foot-cell { display: inline-flex; align-items: center; gap: 4px; }
+.wc-foot kbd { font-size: 9px; padding: 0 4px; }
+
+/* Entrance — one subtle, staggered reveal */
+.wc-head     { animation: wc-in 220ms ease-out both; }
+.wc-status   { animation: wc-in 220ms ease-out 40ms  both; }
+.wc-actions  { animation: wc-in 220ms ease-out 80ms  both; }
+.wc-links    { animation: wc-in 220ms ease-out 120ms both; }
+.wc-foot     { animation: wc-in 220ms ease-out 160ms both; }
+
+@keyframes wc-in {
+  from { opacity: 0; transform: translateY(3px); }
+  to   { opacity: 1; transform: none; }
 }
 
-.link-icon {
-  font-size: 16px;
-  color: var(--color-text-secondary);
-}
-
-.footer {
-  margin-top: var(--spacing-2xl);
-  text-align: center;
-  font-size: var(--font-size-xs);
-  color: var(--color-text-tertiary);
-}
-
-/* Animations */
-.header {
-  animation: slideInDown var(--transition-normal);
-}
-
-.action-grid {
-  animation: scaleIn var(--transition-normal) 0.1s backwards;
-}
-
-.usage-section {
-  animation: slideInUp var(--transition-normal) 0.2s backwards;
-}
-
-.quick-links {
-  animation: slideInUp var(--transition-normal) 0.3s backwards;
+@media (prefers-reduced-motion: reduce) {
+  .wc-head, .wc-status, .wc-actions, .wc-links, .wc-foot { animation: none; }
+  .wc-prompt-caret { animation: none; opacity: 1; }
 }

--- a/media/webview/welcome/welcome.js
+++ b/media/webview/welcome/welcome.js
@@ -1,81 +1,92 @@
 import { postMessage, onMessage } from '../shared/utils/messaging.js';
-import { getById, setInnerHTML, addClasses, removeClasses } from '../shared/utils/dom.js';
+import { getById } from '../shared/utils/dom.js';
 
-// Initialize
+const ACTIONS = [
+  { id: 'action-diagram',     command: 'generateDiagram' },
+  { id: 'action-selection',   command: 'generateFromSelection' },
+  { id: 'action-infographic', command: 'createInfographic' },
+  { id: 'action-image',       command: 'generateImage' },
+  { id: 'action-history',     command: 'viewHistory' },
+];
+
 document.addEventListener('DOMContentLoaded', () => {
-  // Request initial data
   postMessage('checkUsage');
+  wireActions();
+  wireShortcuts();
+  wireLinks();
 
-  // Set up event listeners
-  setupEventListeners();
-
-  // Set up message listeners
-  onMessage({
-    updateUsage: handleUpdateUsage
-  });
+  onMessage({ updateUsage: renderUsage });
 });
 
-function setupEventListeners() {
-  // Action Cards
-  const actions = [
-    { id: 'action-diagram', command: 'generateDiagram' },
-    { id: 'action-infographic', command: 'createInfographic' },
-    { id: 'action-image', command: 'generateImage' },
-    { id: 'action-history', command: 'viewHistory' }
-  ];
+function wireActions() {
+  for (const { id, command } of ACTIONS) {
+    const el = getById(id);
+    if (!el) continue;
+    el.addEventListener('click', () => postMessage(command));
+  }
+}
 
-  actions.forEach(({ id, command }) => {
-    const element = getById(id);
-    if (element) {
-      element.addEventListener('click', () => {
-        postMessage(command);
-      });
+function wireShortcuts() {
+  // Press 1–5 to trigger the matching tile. Ignore when typing in an input.
+  document.addEventListener('keydown', (e) => {
+    const tag = (e.target && e.target.tagName) || '';
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || e.metaKey || e.ctrlKey || e.altKey) return;
+    const idx = parseInt(e.key, 10);
+    if (!Number.isInteger(idx) || idx < 1 || idx > ACTIONS.length) return;
+    const { command } = ACTIONS[idx - 1];
+    postMessage(command);
+    const tile = getById(ACTIONS[idx - 1].id);
+    if (tile) {
+      tile.animate(
+        [{ background: 'var(--fc-surface-hi)' }, { background: 'transparent' }],
+        { duration: 220, easing: 'ease-out' }
+      );
     }
   });
+}
 
-  // Quick Links
-  const settingsLink = getById('link-settings');
-  if (settingsLink) {
-    settingsLink.addEventListener('click', (e) => {
+function wireLinks() {
+  const settings = getById('link-settings');
+  if (settings) {
+    settings.addEventListener('click', (e) => {
       e.preventDefault();
       postMessage('openSettings');
     });
   }
 }
 
-function handleUpdateUsage(usage) {
-  const progressBar = getById('usage-progress');
-  const progressFill = getById('usage-fill');
-  const usageText = getById('usage-text');
-  const limitText = getById('usage-limit');
-  const badgeContainer = getById('subscription-badge');
-
+function renderUsage(usage) {
   if (!usage) return;
 
-  // Update subscription status
+  const progress  = getById('usage-progress');
+  const fill      = getById('usage-fill');
+  const text      = getById('usage-text');
+  const limit     = getById('usage-limit');
+  const badge     = getById('subscription-badge');
+  const footMode  = getById('foot-mode');
+
   if (usage.subscribed) {
-    badgeContainer.innerHTML = '<span class="badge badge-success">Pro</span>';
-    limitText.textContent = 'Unlimited';
-    if (progressBar) progressBar.style.display = 'none';
-    usageText.textContent = `${usage.diagramsCreated} diagrams created`;
+    badge.className = 'tag tag-pro';
+    badge.innerHTML = '<span class="dot"></span>pro';
+    if (progress) progress.classList.add('hidden');
+    text.textContent  = `${usage.diagramsCreated} diagrams generated`;
+    limit.textContent = '∞';
+    if (footMode) footMode.textContent = 'pro';
   } else {
-    badgeContainer.innerHTML = '<span class="badge badge-secondary">Free</span>';
-    limitText.textContent = `${usage.freeLimit} limit`;
+    badge.className = 'tag';
+    badge.innerHTML = '<span class="dot"></span>free';
+    if (progress) progress.classList.remove('hidden');
 
-    // Update progress bar
-    const percentage = Math.min(100, (usage.diagramsCreated / usage.freeLimit) * 100);
-    if (progressFill) {
-      progressFill.style.width = `${percentage}%`;
-
-      // Color coding
-      removeClasses(progressFill, 'bg-warning', 'bg-error');
-      if (percentage >= 90) {
-        addClasses(progressFill, 'bg-error');
-      } else if (percentage >= 70) {
-        addClasses(progressFill, 'bg-warning');
-      }
+    const pct = Math.min(100, (usage.diagramsCreated / usage.freeLimit) * 100);
+    if (fill) {
+      fill.style.width = `${pct}%`;
+      fill.classList.remove('warn', 'err');
+      if (pct >= 90)      fill.classList.add('err');
+      else if (pct >= 70) fill.classList.add('warn');
     }
 
-    usageText.textContent = `${usage.diagramsCreated} / ${usage.freeLimit}`;
+    text.textContent  = `[${usage.diagramsCreated}/${usage.freeLimit}] diagrams`;
+    limit.textContent = `${Math.max(0, usage.freeLimit - usage.diagramsCreated)} left`;
+    if (footMode) footMode.textContent = 'byok';
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,75 +54,26 @@ async function promptForProviderApiKey(
   apiKeyService: APIKeyService,
   provider: Provider
 ): Promise<string | undefined> {
-  // Get provider-specific validation info
-  let prompt = "";
-  let placeholder = "";
-  let validateInput: (value: string) => string | null;
-
-  switch (provider) {
-    case Provider.OpenAI:
-      prompt = "Please enter your OpenAI API key (starts with 'sk-')";
-      placeholder = "sk-...";
-      validateInput = (value: string) => {
-        if (!value.startsWith("sk-")) {
-          return 'OpenAI API key should start with "sk-"';
-        }
-        if (value.length < 20) {
-          return "Invalid API key length";
-        }
-        return null;
-      };
-      break;
-    case Provider.Anthropic:
-      prompt = "Please enter your Anthropic API key (starts with 'sk-ant-')";
-      placeholder = "sk-ant-...";
-      validateInput = (value: string) => {
-        if (!value.startsWith("sk-ant-")) {
-          return 'Anthropic API key should start with "sk-ant-"';
-        }
-        if (value.length < 20) {
-          return "Invalid API key length";
-        }
-        return null;
-      };
-      break;
-    case Provider.Google:
-      prompt = "Please enter your Google (Gemini) API key";
-      placeholder = "Your Google API key";
-      validateInput = (value: string) => {
-        if (value.length < 20) {
-          return "Invalid API key length";
-        }
-        return null;
-      };
-      break;
-    case Provider.FlowCraft:
-      prompt = "Please enter your FlowCraft API key";
-      placeholder = "Your FlowCraft API key";
-      validateInput = (value: string) => {
-        if (value.length < 10) {
-          return "Invalid API key length";
-        }
-        return null;
-      };
-      break;
-    default:
-      prompt = `Please enter your ${provider} API key`;
-      placeholder = "API key";
-      validateInput = (value: string) => {
-        if (value.length < 10) {
-          return "Invalid API key length";
-        }
-        return null;
-      };
-  }
+  const specs: Record<string, { title: string; prompt: string; placeholder: string; prefix?: string; minLen: number }> = {
+    [Provider.OpenAI]:    { title: "api.openai",    prompt: "Paste your OpenAI key · stored in vscode.secrets",        placeholder: "sk-…",      prefix: "sk-",     minLen: 20 },
+    [Provider.Anthropic]: { title: "api.anthropic", prompt: "Paste your Anthropic key · stored in vscode.secrets",     placeholder: "sk-ant-…",  prefix: "sk-ant-", minLen: 20 },
+    [Provider.Google]:    { title: "api.google",    prompt: "Paste your Google (Gemini) key · stored in vscode.secrets", placeholder: "AIza…",   prefix: "AIza",    minLen: 20 },
+    [Provider.FlowCraft]: { title: "api.flowcraft", prompt: "Paste your FlowCraft token · stored in vscode.secrets",   placeholder: "fc_…",      prefix: "fc_",     minLen: 10 },
+  };
+  const spec = specs[provider] ?? { title: `api.${provider}`, prompt: `Enter your ${provider} API key`, placeholder: "key…", minLen: 10 };
 
   const apiKey = await vscode.window.showInputBox({
-    prompt,
-    placeHolder: placeholder,
+    title: `FlowCraft · ${spec.title}`,
+    prompt: spec.prompt,
+    placeHolder: spec.placeholder,
     password: true,
     ignoreFocusOut: true,
-    validateInput,
+    validateInput: (value: string) => {
+      if (!value) return "Key is required";
+      if (spec.prefix && !value.startsWith(spec.prefix)) return `Expected prefix "${spec.prefix}"`;
+      if (value.length < spec.minLen) return "Key looks too short";
+      return null;
+    },
   });
 
   if (apiKey) {
@@ -130,6 +81,61 @@ async function promptForProviderApiKey(
     return apiKey;
   }
   return undefined;
+}
+
+/** Show an API-key error with an "Open Settings" action. */
+function showApiKeyError(provider: string): void {
+  vscode.window
+    .showErrorMessage(
+      `FlowCraft needs a ${provider} API key to generate diagrams.`,
+      "Open Settings",
+      "Dismiss"
+    )
+    .then((choice) => {
+      if (choice === "Open Settings") {
+        vscode.commands.executeCommand("flowcraft.openSettings");
+      }
+    });
+}
+
+/** Collapse verbose upstream errors (litellm / openai / anthropic) into a short toast. */
+function humanizeError(raw: string): { title: string; detail?: string; action?: "billing" | "settings" } {
+  const msg = (raw || "").toLowerCase();
+  if (msg.includes("ratelimiterror") || msg.includes("rate limit") || msg.includes("exceeded your current quota") || msg.includes("insufficient_quota")) {
+    return {
+      title: "Provider quota exceeded",
+      detail: "Your API key has hit its rate limit or quota. Check your billing, then retry.",
+      action: "billing",
+    };
+  }
+  if (msg.includes("authenticationerror") || msg.includes("invalid api key") || msg.includes("incorrect api key") || msg.includes("401")) {
+    return {
+      title: "Invalid API key",
+      detail: "The stored key was rejected by the provider. Open settings to re-enter it.",
+      action: "settings",
+    };
+  }
+  if (msg.includes("403") || msg.includes("permission")) {
+    return { title: "Key lacks permission", detail: "Your key doesn't have access to the requested model." , action: "settings" };
+  }
+  if (msg.includes("timeout") || msg.includes("econnreset") || msg.includes("network")) {
+    return { title: "Network error", detail: "FlowCraft couldn't reach the API. Check your connection and retry." };
+  }
+  // Fallback: strip wrappers like "Failed to generate diagram: litellm.XxxError:"
+  const cleaned = raw.replace(/^(failed to generate diagram:\s*)?(litellm\.[A-Za-z]+Error:\s*)?/i, "").trim();
+  return { title: "Generation failed", detail: cleaned.slice(0, 180) };
+}
+
+/** Open the rendered diagram in the browser with a toast fallback. */
+function openDiagramResult(id: string): void {
+  const url = `https://flowcraft.app/vscode/${id}`;
+  vscode.env.openExternal(vscode.Uri.parse(url));
+  vscode.window
+    .showInformationMessage("Diagram ready.", "Open Diagram", "Copy Link")
+    .then((choice) => {
+      if (choice === "Open Diagram") vscode.env.openExternal(vscode.Uri.parse(url));
+      else if (choice === "Copy Link") vscode.env.clipboard.writeText(url);
+    });
 }
 
 async function ensureProviderApiKey(
@@ -231,63 +237,62 @@ export async function activate(context: vscode.ExtensionContext) {
       } else if (type === "image") {
         vscode.window.showInformationMessage("Image generation coming soon!");
       } else {
-        // Show diagram type selection
-        const diagramTypes = [
-          "FlowChart",
-          "Sequence Diagram",
-          "Class Diagram",
-          "State Diagram",
-          "Entity Relationship Diagram",
-          "User Journey",
-          "Gantt",
-          "Pie Chart",
-          "Quadrant Chart",
-          "Requirement Diagram",
-          "Gitgraph (Git) Diagram",
-          "Mindmaps",
-          "Timeline",
-          "Zenuml",
-          "Sankey",
-          "Treemap",
+        type DiagramItem = vscode.QuickPickItem & { value?: string };
+        const diagramItems: DiagramItem[] = [
+          { label: "Software", kind: vscode.QuickPickItemKind.Separator },
+          { label: "$(symbol-event) FlowChart",          description: "control flow · decisions",         value: "FlowChart",                     detail: "graph TD …" },
+          { label: "$(arrow-both) Sequence Diagram",     description: "message passing between actors",   value: "Sequence Diagram",              detail: "sequenceDiagram …" },
+          { label: "$(symbol-class) Class Diagram",      description: "uml · classes · relationships",    value: "Class Diagram",                 detail: "classDiagram …" },
+          { label: "$(symbol-enum) State Diagram",       description: "states · transitions",             value: "State Diagram",                 detail: "stateDiagram-v2 …" },
+          { label: "$(database) Entity Relationship",    description: "er · schema · tables",             value: "Entity Relationship Diagram",   detail: "erDiagram …" },
+
+          { label: "Planning", kind: vscode.QuickPickItemKind.Separator },
+          { label: "$(calendar) Gantt",                  description: "project timeline",                 value: "Gantt" },
+          { label: "$(pie-chart) Pie Chart",             description: "proportional breakdown",           value: "Pie Chart" },
+          { label: "$(milestone) Timeline",              description: "events on an axis",                value: "Timeline" },
+          { label: "$(organization) Mindmaps",           description: "hierarchical ideas",               value: "Mindmaps" },
+          { label: "$(list-tree) Requirement Diagram",   description: "requirements traceability",       value: "Requirement Diagram" },
+
+          { label: "Advanced", kind: vscode.QuickPickItemKind.Separator },
+          { label: "$(person) User Journey",             description: "user experience flow",             value: "User Journey" },
+          { label: "$(git-branch) Gitgraph",             description: "branch · merge visualisation",    value: "Gitgraph (Git) Diagram" },
+          { label: "$(graph-scatter) Quadrant Chart",    description: "2x2 matrix",                       value: "Quadrant Chart" },
+          { label: "$(zap) Zenuml",                      description: "sequence · z-style",               value: "Zenuml" },
+          { label: "$(symbol-color) Sankey",             description: "weighted flows",                   value: "Sankey" },
+          { label: "$(symbol-structure) Treemap",        description: "nested rectangles",                value: "Treemap" },
         ];
 
-        const selectedType = await vscode.window.showQuickPick(diagramTypes, {
-          placeHolder: "Select diagram type to generate",
+        const picked = await vscode.window.showQuickPick(diagramItems, {
+          title: "FlowCraft · generate",
+          placeHolder: "Pick a diagram type  (type to filter)",
+          matchOnDescription: true,
+          matchOnDetail: true,
         });
 
-        if (!selectedType) {
+        if (!picked || !picked.value) {
           return;
         }
-
-        // Map display names to DiagramType enum values
+        const selectedType = picked.value;
 
         // Ask for code input method
-        const inputMethods = [
-          {
-            label: "Paste Code",
-            description: "Paste code or description directly",
-          },
-          {
-            label: "Select File",
-            description: "Choose a file from your workspace",
-          },
-          {
-            label: "Use Current Selection",
-            description: "Use selected text from the active editor",
-          },
-          {
-            label: "Use Current File",
-            description: "Use entire content of the active file",
-          },
+        type InputItem = vscode.QuickPickItem & { value: string };
+        const inputMethods: InputItem[] = [
+          { label: "$(selection) Use current selection", description: "highlighted text from the active editor",          value: "Use Current Selection" },
+          { label: "$(file-code) Use current file",     description: "entire content of the active file (≤10k chars)",   value: "Use Current File" },
+          { label: "$(folder-opened) Pick a file…",     description: "choose any file from your workspace",              value: "Select File" },
+          { label: "$(edit) Paste code or description", description: "free-form input · prompt-style",                    value: "Paste Code" },
         ];
 
-        const inputMethod = await vscode.window.showQuickPick(inputMethods, {
-          placeHolder: "How would you like to provide the code/description?",
+        const pickedInput = await vscode.window.showQuickPick(inputMethods, {
+          title: `FlowCraft · source for ${selectedType}`,
+          placeHolder: "How should we read the source?",
+          matchOnDescription: true,
         });
 
-        if (!inputMethod) {
+        if (!pickedInput) {
           return;
         }
+        const inputMethod = { label: pickedInput.value };
 
         let codeContent = "";
 
@@ -378,26 +383,21 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.window.withProgress(
           {
             location: vscode.ProgressLocation.Notification,
-            title: `Generating ${selectedType} from FlowCraft`,
+            title: `flowcraft › ${selectedType.toLowerCase()}`,
             cancellable: false,
           },
           async (progress, _token) => {
-            progress.report({ increment: 0 });
+            progress.report({ message: "checking credentials…", increment: 10 });
 
             try {
-              progress.report({ increment: 20 });
-
               // Get API key based on default provider
               const apiKey = await ensureProviderApiKey(stateManager, apiKeyService);
               if (!apiKey) {
-                const defaultProvider = stateManager.getSetting("defaultProvider");
-                vscode.window.showErrorMessage(
-                  `FlowCraft needs a ${defaultProvider} API key to function. Please configure it in the settings.`
-                );
+                showApiKeyError(stateManager.getSetting("defaultProvider"));
                 return;
               }
 
-              progress.report({ increment: 40 });
+              progress.report({ message: "sending prompt to model…", increment: 40 });
 
               const flowCraftApiUrl =
                 process.env.FLOWCRAFT_API_URL || FLOWCRAFT_API_URL;
@@ -435,7 +435,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 }
               );
 
-              progress.report({ increment: 80 });
+              progress.report({ message: "rendering mermaid…", increment: 40 });
 
               if (!response.ok) {
                 const errorData: any = await response.json().catch(() => ({}));
@@ -446,44 +446,51 @@ export async function activate(context: vscode.ExtensionContext) {
               }
 
               const data: any = await response.json();
-              console.log("RESPONSE Data: ", data);
-
               const _res = data.response;
-              const diagram = _res.mermaid_code;
               const inserted_diagram = _res.inserted_diagram;
-
-              console.log("Diagram: ", diagram);
-              console.log("Inserted Diagram: ", inserted_diagram);
 
               if (
                 inserted_diagram &&
                 inserted_diagram.data &&
                 inserted_diagram.data.length > 0
               ) {
-                progress.report({ increment: 100 });
-
-                const diagramUrl = `https://flowcraft.app/vscode/${inserted_diagram.data[0].id}`;
-                vscode.env.openExternal(vscode.Uri.parse(diagramUrl));
-
-                vscode.window
-                  .showInformationMessage(
-                    "The diagram has been successfully generated. If the diagram does not open automatically, please click on the link below.",
-                    "Open Diagram"
-                  )
-                  .then((selection) => {
-                    if (selection === "Open Diagram") {
-                      vscode.env.openExternal(vscode.Uri.parse(diagramUrl));
-                    }
-                  });
+                progress.report({ message: "done", increment: 10 });
+                openDiagramResult(inserted_diagram.data[0].id);
               } else {
                 vscode.window.showErrorMessage(
-                  "An error occurred while generating the diagram. Please try again later."
+                  "FlowCraft didn't return a diagram. Try again or tweak your prompt."
                 );
               }
             } catch (error: any) {
-              vscode.window.showErrorMessage(
-                `An error occurred while generating the diagram: ${error.message}`
-              );
+              const friendly = humanizeError(error?.message ?? String(error));
+              const actions = friendly.action === "billing"
+                ? ["Open Billing", "Switch Provider", "Retry"]
+                : friendly.action === "settings"
+                ? ["Open Settings", "Retry"]
+                : ["Retry", "Open Settings"];
+              vscode.window
+                .showErrorMessage(
+                  friendly.detail ? `${friendly.title} · ${friendly.detail}` : friendly.title,
+                  ...actions
+                )
+                .then((choice) => {
+                  if (choice === "Retry") {
+                    vscode.commands.executeCommand("flowcraft.openGenerationView");
+                  } else if (choice === "Open Settings") {
+                    vscode.commands.executeCommand("flowcraft.openSettings");
+                  } else if (choice === "Switch Provider") {
+                    vscode.commands.executeCommand("flowcraft.openSettings");
+                  } else if (choice === "Open Billing") {
+                    const prov = stateManager.getSetting("defaultProvider");
+                    const billing: Record<string, string> = {
+                      openai: "https://platform.openai.com/account/billing",
+                      anthropic: "https://console.anthropic.com/settings/billing",
+                      google: "https://aistudio.google.com/app/apikey",
+                      flowcraft: "https://flowcraft.app/dashboard/billing",
+                    };
+                    vscode.env.openExternal(vscode.Uri.parse(billing[prov] || "https://flowcraft.app"));
+                  }
+                });
               console.error("Error generating diagram:", error);
             }
           }
@@ -497,17 +504,29 @@ export async function activate(context: vscode.ExtensionContext) {
     async () => {
       const recent = await diagramService.getRecent();
       if (recent.length === 0) {
-        vscode.window.showInformationMessage("No diagram history found.");
+        vscode.window
+          .showInformationMessage(
+            "No diagrams yet. Generate one to populate your history.",
+            "Generate"
+          )
+          .then((choice) => {
+            if (choice === "Generate") {
+              vscode.commands.executeCommand("flowcraft.openGenerationView");
+            }
+          });
         return;
       }
       const items = recent.map((d) => ({
-        label: d.title,
+        label: `$(graph) ${d.title}`,
         description: d.type,
         detail: d.description,
         id: d.id,
       }));
       const selection = await vscode.window.showQuickPick(items, {
-        placeHolder: "Select a diagram to view",
+        title: "FlowCraft · history",
+        placeHolder: `${recent.length} recent diagram${recent.length === 1 ? "" : "s"} · type to filter`,
+        matchOnDescription: true,
+        matchOnDetail: true,
       });
       if (selection) {
         const diagramUrl = `https://flowcraft.app/vscode/${selection.id}`;
@@ -532,7 +551,7 @@ export async function activate(context: vscode.ExtensionContext) {
       vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
-          title: "Generating Diagram from FlowCraft",
+          title: "flowcraft › generating",
           cancellable: false,
         },
         (progress, _token) => {
@@ -580,10 +599,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
             const apiKey = await ensureProviderApiKey(stateManager, apiKeyService);
             if (!apiKey) {
-              const defaultProvider = stateManager.getSetting("defaultProvider");
-              vscode.window.showErrorMessage(
-                `FlowCraft needs a ${defaultProvider} API key to function. Please configure it in the settings.`
-              );
+              showApiKeyError(stateManager.getSetting("defaultProvider"));
               return;
             }
 
@@ -657,7 +673,7 @@ export async function activate(context: vscode.ExtensionContext) {
       vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
-          title: "Generating Diagram from FlowCraft",
+          title: "flowcraft › generating",
           cancellable: false,
         },
         (progress, _token) => {
@@ -698,10 +714,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
             const apiKey = await ensureProviderApiKey(stateManager, apiKeyService);
             if (!apiKey) {
-              const defaultProvider = stateManager.getSetting("defaultProvider");
-              vscode.window.showErrorMessage(
-                `FlowCraft needs a ${defaultProvider} API key to function. Please configure it in the settings.`
-              );
+              showApiKeyError(stateManager.getSetting("defaultProvider"));
               return;
             }
 
@@ -768,7 +781,7 @@ export async function activate(context: vscode.ExtensionContext) {
       vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
-          title: "Generating Diagram from FlowCraft",
+          title: "flowcraft › generating",
           cancellable: false,
         },
         (progress, _token) => {
@@ -798,10 +811,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
             const apiKey = await ensureProviderApiKey(stateManager, apiKeyService);
             if (!apiKey) {
-              const defaultProvider = stateManager.getSetting("defaultProvider");
-              vscode.window.showErrorMessage(
-                `FlowCraft needs a ${defaultProvider} API key to function. Please configure it in the settings.`
-              );
+              showApiKeyError(stateManager.getSetting("defaultProvider"));
               return;
             }
 
@@ -869,7 +879,7 @@ export async function activate(context: vscode.ExtensionContext) {
       vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
-          title: "Generating Diagram from FlowCraft",
+          title: "flowcraft › generating",
           cancellable: false,
         },
         (progress, _token) => {
@@ -899,10 +909,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
             const apiKey = await ensureProviderApiKey(stateManager, apiKeyService);
             if (!apiKey) {
-              const defaultProvider = stateManager.getSetting("defaultProvider");
-              vscode.window.showErrorMessage(
-                `FlowCraft needs a ${defaultProvider} API key to function. Please configure it in the settings.`
-              );
+              showApiKeyError(stateManager.getSetting("defaultProvider"));
               return;
             }
 

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -69,7 +69,7 @@ export async function readFile(uri: vscode.Uri): Promise<string> {
  * Write file content
  */
 export async function writeFile(uri: vscode.Uri, content: string): Promise<void> {
-  const bytes = Buffer.from(content, 'utf-8');
+  const bytes = new TextEncoder().encode(content);
   await vscode.workspace.fs.writeFile(uri, bytes);
 }
 

--- a/src/views/welcome-view.ts
+++ b/src/views/welcome-view.ts
@@ -34,6 +34,7 @@ export class WelcomeViewProvider implements vscode.WebviewViewProvider {
     // Handle messages from webview
     setupMessageListener(webviewView.webview, {
       generateDiagram: async () => { await vscode.commands.executeCommand('flowcraft.openGenerationView'); },
+      generateFromSelection: async () => { await vscode.commands.executeCommand('flowcraft.generateFromSelection'); },
       createInfographic: async () => { await vscode.commands.executeCommand('flowcraft.openGenerationView', 'infographic'); },
       generateImage: async () => { await vscode.commands.executeCommand('flowcraft.openGenerationView', 'image'); },
       viewHistory: async () => { await vscode.commands.executeCommand('flowcraft.showHistory'); },

--- a/src/webview/settings/index.html
+++ b/src/webview/settings/index.html
@@ -4,166 +4,156 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src {{cspSource}} 'unsafe-inline'; script-src 'nonce-{{nonce}}'; img-src {{cspSource}} https: data:;">
-    <title>FlowCraft Settings</title>
-    
+    <title>FlowCraft · settings</title>
+
     <link rel="stylesheet" href="{{themeCss}}">
     <link rel="stylesheet" href="{{componentsCss}}">
     <link rel="stylesheet" href="{{settingsCss}}">
     <link rel="stylesheet" href="{{codiconCss}}">
 </head>
 <body>
-    <div class="settings-container">
-        <div class="header">
-            <h1>Settings</h1>
-            <div class="header-actions">
-                <button class="btn-icon" id="reset-btn" title="Reset to defaults">
-                    <i class="codicon codicon-refresh"></i>
+    <main class="st">
+
+        <header class="st-head">
+            <div class="st-path">
+                <span class="muted">flowcraft</span>
+                <span class="dim">/</span>
+                <span>settings.toml</span>
+            </div>
+            <div class="st-actions">
+                <button class="btn-icon" id="reveal-btn" title="show / hide keys">
+                    <i class="codicon codicon-eye"></i>
+                </button>
+                <button class="btn-icon" id="reset-btn" title="reset to defaults (⌘R)">
+                    <i class="codicon codicon-debug-restart"></i>
                 </button>
             </div>
-        </div>
+        </header>
 
-        <!-- AI Providers Section -->
-        <div class="section">
-            <div class="section-header">
-                <div class="section-title">AI Providers</div>
+        <!-- ————— providers ————— -->
+        <section class="st-section">
+            <span class="section-marker">providers · byok</span>
+
+            <!-- OpenAI -->
+            <div class="row">
+                <div class="row-head">
+                    <span class="row-key"><span class="prefix">api.</span>openai</span>
+                    <span class="row-hint">gpt-4o · gpt-4 · gpt-3.5 · prefix <code>sk-</code></span>
+                </div>
+                <div class="row-control">
+                    <input type="password" class="input" id="key-openai" placeholder="sk-…" autocomplete="off" spellcheck="false">
+                    <button class="btn btn-sm" id="test-openai">test</button>
+                </div>
+                <div class="row-foot">
+                    <span id="status-openai" class="status">unset</span>
+                    <span class="dim">stored in vscode.secrets</span>
+                </div>
             </div>
-            <div class="section-content">
-                
-                <!-- OpenAI -->
-                <div class="form-row top-align">
-                    <div class="form-label">
-                        OpenAI
-                        <div class="form-helper">GPT-4, GPT-3.5 Turbo</div>
-                    </div>
-                    <div class="form-control api-key-container">
-                        <div class="api-key-input-group">
-                            <input type="password" class="input" id="key-openai" placeholder="sk-None...">
-                        </div>
-                        <div class="flex justify-between items-center" style="margin-top: 6px;">
-                             <div class="form-helper" id="status-openai">Securely stored</div>
-                             <button class="btn btn-secondary" id="test-openai" style="font-size: 11px; padding: 4px 10px;">Test Connection</button>
-                        </div>
-                    </div>
-                </div>
 
-                <!-- Anthropic -->
-                <div class="form-row top-align">
-                    <div class="form-label">
-                        Anthropic
-                        <div class="form-helper">Claude 3 Opus, Sonnet</div>
-                    </div>
-                    <div class="form-control api-key-container">
-                        <div class="api-key-input-group">
-                            <input type="password" class="input" id="key-anthropic" placeholder="sk-ant-...">
-                        </div>
-                        <div class="flex justify-between items-center" style="margin-top: 6px;">
-                             <div class="form-helper" id="status-anthropic">Securely stored</div>
-                             <button class="btn btn-secondary" id="test-anthropic" style="font-size: 11px; padding: 4px 10px;">Test Connection</button>
-                        </div>
-                    </div>
+            <!-- Anthropic -->
+            <div class="row">
+                <div class="row-head">
+                    <span class="row-key"><span class="prefix">api.</span>anthropic</span>
+                    <span class="row-hint">claude 3 opus · sonnet · haiku · prefix <code>sk-ant-</code></span>
                 </div>
-
-                <!-- Google -->
-                <div class="form-row top-align">
-                    <div class="form-label">
-                        Google
-                        <div class="form-helper">Gemini Pro</div>
-                    </div>
-                    <div class="form-control api-key-container">
-                        <div class="api-key-input-group">
-                            <input type="password" class="input" id="key-google" placeholder="AIza...">
-                        </div>
-                        <div class="flex justify-between items-center" style="margin-top: 6px;">
-                             <div class="form-helper" id="status-google">Securely stored</div>
-                             <button class="btn btn-secondary" id="test-google" style="font-size: 11px; padding: 4px 10px;">Test Connection</button>
-                        </div>
-                    </div>
+                <div class="row-control">
+                    <input type="password" class="input" id="key-anthropic" placeholder="sk-ant-…" autocomplete="off" spellcheck="false">
+                    <button class="btn btn-sm" id="test-anthropic">test</button>
                 </div>
-
-                <!-- FlowCraft (Native) -->
-                <div class="form-row top-align">
-                    <div class="form-label">
-                        FlowCraft Cloud
-                        <div class="form-helper">Specialized Models</div>
-                    </div>
-                    <div class="form-control api-key-container">
-                        <div class="api-key-input-group">
-                            <input type="password" class="input" id="key-flowcraft" placeholder="fc_...">
-                        </div>
-                        <div class="flex justify-between items-center" style="margin-top: 6px;">
-                             <div class="form-helper" id="status-flowcraft">Account token</div>
-                             <button class="btn btn-secondary" id="test-flowcraft" style="font-size: 11px; padding: 4px 10px;">Test Connection</button>
-                        </div>
-                    </div>
+                <div class="row-foot">
+                    <span id="status-anthropic" class="status">unset</span>
+                    <span class="dim">stored in vscode.secrets</span>
                 </div>
-
             </div>
-        </div>
 
-        <!-- General Preferences -->
-        <div class="section">
-            <div class="section-header">
-                <div class="section-title">Preferences</div>
+            <!-- Google -->
+            <div class="row">
+                <div class="row-head">
+                    <span class="row-key"><span class="prefix">api.</span>google</span>
+                    <span class="row-hint">gemini pro · prefix <code>AIza</code></span>
+                </div>
+                <div class="row-control">
+                    <input type="password" class="input" id="key-google" placeholder="AIza…" autocomplete="off" spellcheck="false">
+                    <button class="btn btn-sm" id="test-google">test</button>
+                </div>
+                <div class="row-foot">
+                    <span id="status-google" class="status">unset</span>
+                    <span class="dim">stored in vscode.secrets</span>
+                </div>
             </div>
-            <div class="section-content">
-                
-                <div class="form-row">
-                    <label class="form-label" for="default-provider">Default Provider</label>
-                    <div class="form-control">
-                        <select class="input" id="default-provider" style="width: auto; min-width: 140px;">
-                            <option value="openai">OpenAI</option>
-                            <option value="anthropic">Anthropic</option>
-                            <option value="google">Google</option>
-                            <option value="flowcraft">FlowCraft Cloud</option>
-                        </select>
-                    </div>
-                </div>
 
-                <div class="form-row">
-                    <label class="form-label" for="default-type">Default Diagram</label>
-                    <div class="form-control">
-                         <select class="input" id="default-type" style="width: auto; min-width: 140px;">
-                            <option value="flowchart">Flowchart</option>
-                            <option value="sequence">Sequence Diagram</option>
-                            <option value="class">Class Diagram</option>
-                            <option value="state">State Diagram</option>
-                            <option value="er">ER Diagram</option>
-                            <option value="gantt">Gantt Chart</option>
-                            <option value="pie">Pie Chart</option>
-                        </select>
-                    </div>
+            <!-- FlowCraft -->
+            <div class="row">
+                <div class="row-head">
+                    <span class="row-key"><span class="prefix">api.</span>flowcraft</span>
+                    <span class="row-hint">native cloud · prefix <code>fc_</code></span>
                 </div>
-
-                <div class="form-row">
-                    <label class="form-label" for="default-palette">Default Colors</label>
-                    <div class="form-control">
-                        <select class="input" id="default-palette" style="width: auto; min-width: 140px;">
-                            <option value="brand colors">Brand Colors</option>
-                            <option value="monochromatic">Monochromatic</option>
-                            <option value="complementary">Complementary</option>
-                            <option value="analogous">Analogous</option>
-                        </select>
-                    </div>
+                <div class="row-control">
+                    <input type="password" class="input" id="key-flowcraft" placeholder="fc_…" autocomplete="off" spellcheck="false">
+                    <button class="btn btn-sm" id="test-flowcraft">test</button>
                 </div>
-
-                <div class="form-row">
-                    <label class="form-label" for="default-complexity">Complexity</label>
-                    <div class="form-control">
-                        <select class="input" id="default-complexity" style="width: auto; min-width: 140px;">
-                            <option value="simple">Simple</option>
-                            <option value="medium">Medium</option>
-                            <option value="complex">Complex</option>
-                        </select>
-                    </div>
+                <div class="row-foot">
+                    <span id="status-flowcraft" class="status">unset</span>
+                    <span class="dim">stored in vscode.secrets</span>
                 </div>
-                
             </div>
-        </div>
-    </div>
+        </section>
 
-    <div class="actions-bar">
-        <button class="btn btn-primary" id="save-btn" style="min-width: 120px;">Save Changes</button>
-    </div>
+        <!-- ————— preferences ————— -->
+        <section class="st-section">
+            <span class="section-marker">defaults</span>
+
+            <div class="row row-inline">
+                <span class="row-key"><span class="prefix">default.</span>provider</span>
+                <select class="input input-inline" id="default-provider">
+                    <option value="openai">openai</option>
+                    <option value="anthropic">anthropic</option>
+                    <option value="google">google</option>
+                    <option value="flowcraft">flowcraft</option>
+                </select>
+            </div>
+
+            <div class="row row-inline">
+                <span class="row-key"><span class="prefix">default.</span>diagram</span>
+                <select class="input input-inline" id="default-type">
+                    <option value="flowchart">flowchart</option>
+                    <option value="sequence">sequence</option>
+                    <option value="class">class</option>
+                    <option value="state">state</option>
+                    <option value="er">er</option>
+                    <option value="gantt">gantt</option>
+                    <option value="pie">pie</option>
+                </select>
+            </div>
+
+            <div class="row row-inline">
+                <span class="row-key"><span class="prefix">default.</span>palette</span>
+                <select class="input input-inline" id="default-palette">
+                    <option value="brand colors">brand</option>
+                    <option value="monochromatic">monochromatic</option>
+                    <option value="complementary">complementary</option>
+                    <option value="analogous">analogous</option>
+                </select>
+            </div>
+
+            <div class="row row-inline">
+                <span class="row-key"><span class="prefix">default.</span>complexity</span>
+                <select class="input input-inline" id="default-complexity">
+                    <option value="simple">simple</option>
+                    <option value="medium">medium</option>
+                    <option value="complex">complex</option>
+                </select>
+            </div>
+        </section>
+
+    </main>
+
+    <footer class="st-foot">
+        <span class="st-foot-cell"><span class="dim">⌘S</span> save</span>
+        <span class="st-foot-cell"><span class="dim">⌘R</span> reset</span>
+        <span class="st-foot-cell" id="foot-status">idle</span>
+        <button class="btn btn-primary" id="save-btn">save changes</button>
+    </footer>
 
     <script type="module" nonce="{{nonce}}" src="{{settingsJs}}"></script>
 </body>

--- a/src/webview/settings/settings.css
+++ b/src/webview/settings/settings.css
@@ -1,251 +1,117 @@
-/* Settings View Specific Styles - Apple Aesthetic Minimalist */
+/* Settings — config-file layout */
 
-body {
-  padding: var(--spacing-lg);
-  overflow-x: hidden;
-  background-color: var(--color-bg);
-  color: var(--color-text-primary);
-}
+body { padding: 0; overflow-x: hidden; }
 
-.settings-container {
-  max-width: 680px; /* Optimal reading width */
-  margin: 0 auto;
-  padding-bottom: 80px; /* Space for sticky footer */
-}
-
-/* Header */
-.header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-bottom: var(--spacing-xl);
-  padding: 0 var(--spacing-sm);
-}
-
-.header h1 {
-  font-size: 34px;
-  font-weight: 700;
-  letter-spacing: -0.5px;
-}
-
-.header-actions {
-  display: flex;
-  gap: var(--spacing-md);
-}
-
-.btn-icon {
-  background: transparent;
-  border: none;
-  color: var(--color-primary);
-  border-radius: 50%;
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background-color var(--transition-fast);
-  cursor: pointer;
-}
-
-.btn-icon:hover {
-  background-color: rgba(128, 128, 128, 0.1);
-}
-
-.btn-icon i {
-  font-size: 16px;
-}
-
-/* Sections / Groups */
-.section {
-  margin-bottom: var(--spacing-xl);
-}
-
-.section-header {
-  padding: 0 var(--spacing-md) var(--spacing-sm);
-  margin-bottom: var(--spacing-xs);
-}
-
-.section-title {
-  font-size: 13px;
-  text-transform: uppercase;
-  color: var(--color-text-secondary);
-  font-weight: 500;
-  letter-spacing: -0.2px;
-}
-
-.section-content {
-  background-color: var(--color-surface);
-  border-radius: var(--radius-md);
-  overflow: hidden;
-  /* No border, rely on background contrast or shadow */
-  box-shadow: var(--shadow-sm); 
-}
-
-
-/* Form Items - Apple Style Lists */
-.form-row {
-  display: flex;
-  align-items: center;
-  padding: var(--spacing-md) var(--spacing-lg);
-  background-color: var(--color-surface);
-  border-bottom: 1px solid var(--color-divider);
-  min-height: 44px;
-}
-
-.form-row:last-child {
-  border-bottom: none;
-}
-
-.form-row.top-align {
-  align-items: flex-start;
-}
-
-.form-label {
-  flex: 1;
-  font-size: var(--font-size-md);
-  color: var(--color-text-primary);
-  font-weight: 400;
-}
-
-.form-control {
-  flex: 2;
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-}
-
-/* Inputs */
-.input {
-  width: 100%; 
-  padding: 8px 12px;
-  font-size: var(--font-size-md);
-  border: 1px solid transparent;
-  background-color: var(--color-bg); /* Light grey bg inside white card */
-  border-radius: var(--radius-sm);
-  color: var(--color-text-primary);
-  transition: all var(--transition-fast);
-  font-family: var(--font-family-mono);
-}
-
-.input:focus {
-  outline: none;
-  background-color: var(--color-surface-elevated);
-  box-shadow: 0 0 0 2px var(--color-primary);
-}
-
-/* Select inputs need specific styling to look good */
-select.input {
-  font-family: var(--font-family-body);
-  cursor: pointer;
-}
-
-/* API Key Specifics */
-.api-key-container {
+.st {
+  padding: var(--fc-sp-5);
+  padding-bottom: 72px; /* room for sticky footer */
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-sm);
-  width: 100%;
+  gap: var(--fc-sp-7);
+  max-width: 820px;
+  margin: 0 auto;
 }
 
-.api-key-input-group {
+/* Head ——————————————————————————— */
+.st-head {
   display: flex;
-  gap: var(--spacing-sm);
-  width: 100%;
-}
-
-.api-key-input-group .input {
-  flex-grow: 1;
-}
-
-.form-helper {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-secondary);
-  padding-top: 4px;
-}
-
-.provider-status-badge {
-    font-size: 11px;
-    padding: 2px 8px;
-    border-radius: 12px;
-    font-weight: 500;
-    background-color: var(--color-bg);
-    color: var(--color-text-secondary);
-}
-
-.provider-status-badge.configured {
-    color: var(--color-text-inverse);
-    background-color: var(--color-text-primary); /* Black badge */
-}
-
-/* Buttons */
-.btn {
-  padding: 6px 16px;
-  border-radius: 18px; /* Pill shape */
-  border: none;
-  font-size: var(--font-size-sm);
-  font-weight: 500;
-  cursor: pointer;
-  transition: opacity var(--transition-fast);
-}
-
-.btn:hover {
-  opacity: 0.8;
-}
-
-.btn:active {
-  opacity: 0.6;
-}
-
-.btn:disabled {
-  opacity: 0.3;
-  cursor: default;
-}
-
-.btn-primary {
-  background-color: var(--color-primary);
-  color: var(--color-text-inverse);
-}
-
-.btn-secondary {
-  background-color: var(--color-bg);
-  color: var(--color-text-primary);
-}
-
-/* Footer Actions */
-.actions-bar {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  background-color: rgba(255, 255, 255, 0.8); /* Translucent */
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  padding: var(--spacing-md) var(--spacing-xl);
-  border-top: 1px solid var(--color-divider);
-  display: flex;
-  justify-content: flex-end;
   align-items: center;
-  z-index: var(--z-sticky);
+  justify-content: space-between;
+  gap: var(--fc-sp-4);
+  padding-bottom: var(--fc-sp-4);
+  border-bottom: 1px dashed var(--fc-border);
+}
+.st-path {
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs-md);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.st-path .dim { color: var(--fc-fg-dim); }
+.st-actions { display: inline-flex; gap: var(--fc-sp-2); }
+
+/* Sections ——————————————————————————— */
+.st-section {
+  display: flex;
+  flex-direction: column;
 }
 
-/* Dark mode adjustment for backdrop */
-body[data-vscode-theme-kind="vscode-dark"] .actions-bar,
-body[data-vscode-theme-kind="vscode-high-contrast"] .actions-bar {
-  background-color: rgba(28, 28, 30, 0.8);
+/* Row overrides ——————————————————————————— */
+.row code {
+  padding: 0 3px;
+  background: var(--fc-surface);
+  border: 1px solid var(--fc-border);
+  border-radius: 2px;
+  color: var(--fc-fg);
+  font-size: 10px;
 }
 
-.spinner {
-    border: 2px solid rgba(0,0,0,0.1);
-    border-left-color: currentColor;
-    border-radius: 50%;
-    display: inline-block;
-    animation: spin 1s linear infinite;
+.row-inline {
+  display: grid;
+  grid-template-columns: minmax(200px, 1fr) auto;
+  align-items: center;
+  padding: var(--fc-sp-4) 0;
+  gap: var(--fc-sp-5);
 }
-body[data-vscode-theme-kind="vscode-dark"] .spinner {
-    border-color: rgba(255,255,255,0.1);
-    border-left-color: currentColor;
+.row-inline .row-key {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+}
+.input-inline {
+  width: auto;
+  min-width: 160px;
+  padding: var(--fc-sp-2) var(--fc-sp-4);
+  padding-right: 28px;
 }
 
-@keyframes spin {
-  to { transform: rotate(360deg); }
+/* Status text ——————————————————————————— */
+.status {
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs-sm);
+  color: var(--fc-fg-muted);
+}
+.status.ok  { color: var(--fc-ok); }
+.status.err { color: var(--fc-err); }
+.status.warn { color: var(--fc-warn); }
+.status::before {
+  content: "● ";
+  color: currentColor;
+  opacity: 0.75;
+}
+
+/* Footer action bar (sticky) ——————————————————————————— */
+.st-foot {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--fc-sp-5);
+  padding: var(--fc-sp-3) var(--fc-sp-5);
+  background: color-mix(in srgb, var(--fc-bg) 88%, transparent);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-top: 1px solid var(--fc-border);
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs-sm);
+  color: var(--fc-fg-muted);
+  z-index: 10;
+}
+.st-foot-cell { display: inline-flex; align-items: center; gap: 6px; }
+.st-foot .dim { color: var(--fc-fg-dim); }
+.st-foot #save-btn { margin-left: auto; }
+
+/* Entrance */
+.st-head, .st-section { animation: st-in 220ms ease-out both; }
+.st-section:nth-of-type(2) { animation-delay: 40ms; }
+.st-section:nth-of-type(3) { animation-delay: 80ms; }
+
+@keyframes st-in {
+  from { opacity: 0; transform: translateY(3px); }
+  to   { opacity: 1; transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .st-head, .st-section { animation: none; }
 }

--- a/src/webview/settings/settings.js
+++ b/src/webview/settings/settings.js
@@ -1,169 +1,131 @@
 import { postMessage, onMessage } from '../shared/utils/messaging.js';
 import { getById, queryAll } from '../shared/utils/dom.js';
 
+const PROVIDERS = ['openai', 'anthropic', 'google', 'flowcraft'];
+
 let currentSettings = {};
 let currentProviders = {};
+let keysRevealed = false;
 
 document.addEventListener('DOMContentLoaded', () => {
-  // Load initial settings
   postMessage('loadSettings');
+  wire();
 
-  // Setup interactions
-  setupEventListeners();
-
-  // Message handler
   onMessage({
-    updateSettings: (data) => {
-      currentSettings = data.settings;
-      currentProviders = data.providers;
-      renderSettings();
+    updateSettings: ({ settings, providers }) => {
+      currentSettings = settings;
+      currentProviders = providers;
+      render();
     },
-    connectionResult: (data) => {
-      const statusEl = getById(`status-${data.provider}`);
-      if (statusEl) {
-        statusEl.textContent = data.message;
-        // Reset class then add specific color
-        statusEl.className = 'form-helper';
-        if (data.success) {
-            statusEl.textContent = 'Connection Verified';
-            statusEl.style.color = 'var(--color-success)'; // using style directly or class if defined
-        } else {
-            statusEl.style.color = 'var(--color-error)';
-        }
-      }
-      
-      // Re-enable button
-      const btn = getById(`test-${data.provider}`);
-      if (btn) {
-        btn.disabled = false;
-        btn.innerHTML = 'Test Connection';
-      }
+    connectionResult: ({ provider, success, message }) => {
+      setStatus(provider, success ? 'ok' : 'err', success ? 'verified' : (message || 'failed'));
+      const btn = getById(`test-${provider}`);
+      if (btn) { btn.disabled = false; btn.textContent = 'test'; }
     },
-    saveComplete: (data) => {
+    saveComplete: ({ success }) => {
       const btn = getById('save-btn');
+      const foot = getById('foot-status');
       if (btn) {
-        if (data.success) {
-          btn.textContent = 'Saved ✓';
-          setTimeout(() => {
-            btn.textContent = 'Save Changes';
-            btn.disabled = false;
-          }, 1500);
-        } else {
-          btn.textContent = 'Save Failed';
-          setTimeout(() => {
-            btn.textContent = 'Save Changes';
-            btn.disabled = false;
-          }, 2000);
-        }
+        btn.textContent = success ? 'saved' : 'save failed';
+        btn.disabled = false;
+        setTimeout(() => { btn.textContent = 'save changes'; }, 1400);
+      }
+      if (foot) {
+        foot.textContent = success ? 'changes written' : 'write failed';
+        foot.className = 'st-foot-cell ' + (success ? 'ok' : 'err');
+        setTimeout(() => { foot.textContent = 'idle'; foot.className = 'st-foot-cell'; }, 1800);
       }
     }
   });
 });
 
-function setupEventListeners() {
-  // Test connection buttons
+function wire() {
+  // Test buttons
   queryAll('[id^="test-"]').forEach(btn => {
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
       const provider = btn.id.replace('test-', '');
       const input = getById(`key-${provider}`);
-      const apiKey = input.value;
-
+      const apiKey = input && input.value;
       if (!apiKey) {
-        const statusEl = getById(`status-${provider}`);
-        statusEl.textContent = 'Enter an API key first';
-        statusEl.style.color = 'var(--color-error)';
+        setStatus(provider, 'err', 'enter a key first');
         return;
       }
-
       btn.disabled = true;
-      btn.innerHTML = '<div class="spinner" style="width: 12px; height: 12px; border-width: 2px;"></div> Checking...';
-      
-      postMessage('testConnection', {
-        provider,
-        apiKey
-      });
+      btn.textContent = '…';
+      setStatus(provider, 'warn', 'checking…');
+      postMessage('testConnection', { provider, apiKey });
     });
   });
 
-  // Save button
-  getById('save-btn')?.addEventListener('click', () => {
-    const btn = getById('save-btn');
-    const originalText = btn.textContent;
-    btn.textContent = 'Saving...';
-    btn.disabled = true;
-    
-    saveAllSettings();
-    
-    setTimeout(() => {
-        btn.textContent = originalText;
-        btn.disabled = false;
-    }, 1000);
+  // Save
+  getById('save-btn')?.addEventListener('click', save);
+
+  // Reset
+  getById('reset-btn')?.addEventListener('click', () => {
+    if (confirm('reset all settings to defaults?')) postMessage('resetSettings');
   });
 
-  // Reset button
-  getById('reset-btn')?.addEventListener('click', () => {
-    if(confirm('Reset all settings to default?')) {
-        postMessage('resetSettings');
-    }
+  // Reveal / hide passwords
+  getById('reveal-btn')?.addEventListener('click', () => {
+    keysRevealed = !keysRevealed;
+    PROVIDERS.forEach(p => {
+      const input = getById(`key-${p}`);
+      if (input) input.type = keysRevealed ? 'text' : 'password';
+    });
+  });
+
+  // Keyboard shortcuts
+  document.addEventListener('keydown', (e) => {
+    const mod = e.metaKey || e.ctrlKey;
+    if (mod && e.key === 's') { e.preventDefault(); save(); }
+    if (mod && e.key === 'r') { e.preventDefault(); if (confirm('reset all settings to defaults?')) postMessage('resetSettings'); }
   });
 }
 
-function renderSettings() {
+function save() {
+  const btn = getById('save-btn');
+  if (btn) { btn.disabled = true; btn.textContent = 'saving…'; }
+
+  const newSettings = {
+    ...currentSettings,
+    defaultProvider:     getById('default-provider').value,
+    defaultDiagramType:  getById('default-type').value,
+    defaultColorPalette: getById('default-palette').value,
+    defaultComplexity:   getById('default-complexity').value,
+  };
+
+  const apiKeys = {};
+  PROVIDERS.forEach(p => {
+    const input = getById(`key-${p}`);
+    if (input && input.value) apiKeys[p] = input.value;
+  });
+
+  postMessage('saveSettings', { settings: newSettings, apiKeys });
+}
+
+function render() {
   if (!currentSettings) return;
 
-  // Update status text based on configured providers
-  Object.entries(currentProviders).forEach(([provider, configured]) => {
-    const statusEl = getById(`status-${provider}`);
-    if (statusEl) {
-        if (configured) {
-            statusEl.textContent = 'Configured';
-            statusEl.style.color = 'var(--color-success)'; // Green for configured
-        } else {
-            statusEl.textContent = 'Not Configured';
-            statusEl.style.color = 'var(--color-text-secondary)';
-        }
-    }
+  Object.entries(currentProviders || {}).forEach(([provider, configured]) => {
+    if (configured) setStatus(provider, 'ok', 'configured');
+    else            setStatus(provider, '',   'unset');
   });
 
-  // General Settings
-  setSelectValue('default-provider', currentSettings.defaultProvider);
-  setSelectValue('default-type', currentSettings.defaultDiagramType);
-  setSelectValue('default-palette', currentSettings.defaultColorPalette);
-  setSelectValue('default-complexity', currentSettings.defaultComplexity);
+  setSelect('default-provider',   currentSettings.defaultProvider);
+  setSelect('default-type',       currentSettings.defaultDiagramType);
+  setSelect('default-palette',    currentSettings.defaultColorPalette);
+  setSelect('default-complexity', currentSettings.defaultComplexity);
 }
 
-function setSelectValue(id, value) {
+function setStatus(provider, state, text) {
+  const el = getById(`status-${provider}`);
+  if (!el) return;
+  el.className = 'status' + (state ? ' ' + state : '');
+  el.textContent = text;
+}
+
+function setSelect(id, value) {
   const el = getById(id);
   if (el) el.value = value || '';
-}
-
-function saveAllSettings() {
-  const newSettings = { ...currentSettings };
-  
-  // Get values from form
-  newSettings.defaultProvider = getById('default-provider').value;
-  newSettings.defaultDiagramType = getById('default-type').value;
-  newSettings.defaultColorPalette = getById('default-palette').value;
-  newSettings.defaultComplexity = getById('default-complexity').value;
-
-  // Get API keys
-  const apiKeys = {};
-  const providers = ['openai', 'anthropic', 'google', 'flowcraft'];
-  
-  providers.forEach(provider => {
-    const input = getById(`key-${provider}`);
-    // Only update if value is present (empty fields might mean "keep existing" or "clear" depends on backend)
-    // Assuming backend handles empty string as "don't update" or we send all. 
-    // If user allows clearing, we might need a clearer UI for "Clear Key".
-    // For now, send if value exists.
-    if (input && input.value) {
-      apiKeys[provider] = input.value;
-    }
-  });
-
-  postMessage('saveSettings', {
-    settings: newSettings,
-    apiKeys
-  });
 }

--- a/src/webview/shared/styles/components.css
+++ b/src/webview/shared/styles/components.css
@@ -1,512 +1,237 @@
 /**
- * FlowCraft Reusable Components
- * Apple-inspired component library
+ * Flat, TUI-ish components. Sharp corners, monospace everywhere,
+ * focus shown with a hard 1px border rather than shadows or glows.
  */
 
-/* Buttons */
+/* ——————— Button ——————— */
 .btn {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: var(--spacing-sm);
-  padding: var(--spacing-sm) var(--spacing-lg);
-  font-family: var(--font-family-body);
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-semibold);
-  border-radius: var(--radius-md);
-  border: none;
+  gap: var(--fc-sp-3);
+  padding: var(--fc-sp-3) var(--fc-sp-5);
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs);
+  color: var(--fc-fg);
+  background: transparent;
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius-1);
   cursor: pointer;
-  transition: all var(--transition-normal);
+  transition: background var(--fc-t-fast), border-color var(--fc-t-fast), color var(--fc-t-fast);
   white-space: nowrap;
   user-select: none;
+  line-height: 1.2;
 }
-
 .btn:hover {
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-md);
+  background: var(--fc-surface);
+  border-color: var(--fc-fg-muted);
 }
-
-.btn:active {
-  transform: translateY(0);
-  box-shadow: var(--shadow-sm);
-}
+.btn:active { transform: translateY(1px); }
 
 .btn-primary {
-  background-color: var(--color-primary);
-  color: var(--color-text-inverse);
-  box-shadow: var(--shadow-sm);
+  color: var(--vscode-button-foreground);
+  background: var(--vscode-button-background);
+  border-color: var(--vscode-button-background);
 }
-
 .btn-primary:hover {
-  background-color: color-mix(in srgb, var(--color-primary) 85%, black);
+  background: var(--vscode-button-hoverBackground, var(--vscode-button-background));
+  border-color: var(--vscode-button-hoverBackground, var(--vscode-button-background));
 }
 
-.btn-secondary {
-  background-color: transparent;
-  color: var(--color-primary);
-  border: 1px solid var(--color-border);
-}
+.btn-ghost { border-color: transparent; color: var(--fc-fg-muted); }
+.btn-ghost:hover { color: var(--fc-fg); background: var(--fc-surface); border-color: var(--fc-border); }
 
-.btn-secondary:hover {
-  background-color: var(--color-surface);
-  border-color: var(--color-primary);
-}
-
-.btn-success {
-  background-color: var(--color-success);
-  color: var(--color-text-inverse);
-}
-
-.btn-danger {
-  background-color: var(--color-error);
-  color: var(--color-text-inverse);
-}
-
-.btn-small {
-  padding: 4px 12px;
-  font-size: var(--font-size-sm);
-}
-
-.btn-large {
-  padding: var(--spacing-md) var(--spacing-xl);
-  font-size: var(--font-size-md);
-}
+.btn-sm { padding: var(--fc-sp-2) var(--fc-sp-4); font-size: var(--fc-fs-sm); }
 
 .btn-icon {
-  padding: var(--spacing-sm);
-  border-radius: var(--radius-md);
-  background-color: transparent;
-  color: var(--color-text-primary);
-  border: none;
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 24px; height: 24px; padding: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--fc-fg-muted);
   cursor: pointer;
-  transition: all var(--transition-normal);
+  border-radius: var(--fc-radius-1);
+  transition: color var(--fc-t-fast), background var(--fc-t-fast), border-color var(--fc-t-fast);
+}
+.btn-icon:hover { color: var(--fc-fg); background: var(--fc-surface); border-color: var(--fc-border); }
+.btn-icon i { font-size: 14px; }
+
+/* ——————— Keyboard hint ——————— */
+kbd, .kbd {
+  display: inline-block;
+  padding: 1px 5px;
+  font-family: var(--fc-font-mono);
+  font-size: 10px;
+  line-height: 1.4;
+  color: var(--fc-fg-muted);
+  background: var(--fc-surface);
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius-1);
+  white-space: nowrap;
 }
 
-.btn-icon:hover {
-  background-color: var(--color-surface);
-}
-
-/* Cards */
-.card {
-  background-color: var(--color-surface);
-  border-radius: var(--radius-lg);
-  padding: var(--spacing-lg);
-  border: 1px solid var(--color-border);
-  transition: all var(--transition-normal);
-}
-
-.card-hover {
-  cursor: pointer;
-}
-
-.card-hover:hover {
-  transform: scale(1.02);
-  box-shadow: var(--shadow-md);
-  border-color: var(--color-primary);
-}
-
-.card-title {
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
-  margin-bottom: var(--spacing-sm);
-}
-
-.card-description {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-  line-height: var(--line-height-relaxed);
-}
-
-/* Action Cards */
-.action-card {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  gap: var(--spacing-sm);
-  padding: var(--spacing-lg);
-  background-color: var(--color-surface);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--color-border);
-  cursor: pointer;
-  transition: all var(--transition-normal);
-  min-height: 120px;
-}
-
-.action-card:hover {
-  transform: scale(1.02);
-  box-shadow: var(--shadow-md);
-  border-color: var(--color-primary);
-}
-
-.action-card-icon {
-  font-size: 32px;
-  color: var(--color-primary);
-}
-
-.action-card-title {
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
-}
-
-.action-card-subtitle {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-secondary);
-}
-
-/* Input Fields */
+/* ——————— Input ——————— */
 .input {
   width: 100%;
-  padding: 10px 12px;
-  font-family: var(--font-family-body);
-  font-size: var(--font-size-base);
-  color: var(--color-text-primary);
-  background-color: var(--color-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  transition: all var(--transition-normal);
+  padding: var(--fc-sp-3) var(--fc-sp-4);
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs);
+  color: var(--vscode-input-foreground, var(--fc-fg));
+  background: var(--vscode-input-background, var(--fc-surface));
+  border: 1px solid var(--vscode-input-border, var(--fc-border));
+  border-radius: var(--fc-radius-1);
+  transition: border-color var(--fc-t-fast);
 }
-
 .input:focus {
   outline: none;
-  border-color: var(--color-primary);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 15%, transparent);
+  border-color: var(--fc-border-hi);
+}
+.input::placeholder { color: var(--fc-fg-dim); font-style: normal; }
+
+select.input {
+  cursor: pointer;
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--fc-fg-muted) 50%),
+    linear-gradient(135deg, var(--fc-fg-muted) 50%, transparent 50%);
+  background-position:
+    calc(100% - 14px) 50%,
+    calc(100% - 9px) 50%;
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+  padding-right: 26px;
+  appearance: none;
+  -webkit-appearance: none;
 }
 
-.input::placeholder {
-  color: var(--color-text-secondary);
-}
-
-.input:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.textarea {
-  min-height: 120px;
-  font-family: var(--font-family-mono);
-  resize: vertical;
-}
-
-/* Form Groups */
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-sm);
-  margin-bottom: var(--spacing-md);
-}
-
-.form-label {
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-medium);
-  color: var(--color-text-primary);
-}
-
-.form-helper {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-}
-
-.form-error {
-  font-size: var(--font-size-sm);
-  color: var(--color-error);
-}
-
-/* Badges */
-.badge {
+/* ——————— Status badge (inline) ——————— */
+.tag {
   display: inline-flex;
   align-items: center;
-  padding: 2px 8px;
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-semibold);
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--color-border);
-  background-color: var(--color-surface);
-  color: var(--color-text-primary);
+  gap: 4px;
+  padding: 1px 6px;
+  font-family: var(--fc-font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fc-fg-muted);
+  background: transparent;
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius-1);
+  line-height: 1.4;
 }
+.tag-ok   { color: var(--fc-ok);   border-color: color-mix(in srgb, var(--fc-ok)   35%, transparent); }
+.tag-warn { color: var(--fc-warn); border-color: color-mix(in srgb, var(--fc-warn) 35%, transparent); }
+.tag-err  { color: var(--fc-err);  border-color: color-mix(in srgb, var(--fc-err)  35%, transparent); }
+.tag-pro  { color: var(--fc-accent); border-color: color-mix(in srgb, var(--fc-accent) 35%, transparent); }
 
-.badge-primary {
-  background-color: color-mix(in srgb, var(--color-primary) 15%, transparent);
-  color: var(--color-primary);
-  border-color: color-mix(in srgb, var(--color-primary) 30%, transparent);
-}
-
-.badge-success {
-  background-color: color-mix(in srgb, var(--color-success) 15%, transparent);
-  color: var(--color-success);
-  border-color: color-mix(in srgb, var(--color-success) 30%, transparent);
-}
-
-.badge-warning {
-  background-color: color-mix(in srgb, var(--color-warning) 15%, transparent);
-  color: var(--color-warning);
-  border-color: color-mix(in srgb, var(--color-warning) 30%, transparent);
-}
-
-.badge-error {
-  background-color: color-mix(in srgb, var(--color-error) 15%, transparent);
-  color: var(--color-error);
-  border-color: color-mix(in srgb, var(--color-error) 30%, transparent);
-}
-
-/* Progress Bar */
-.progress-bar {
-  width: 100%;
-  height: 4px;
-  background-color: var(--color-surface);
-  border-radius: var(--radius-sm);
-  overflow: hidden;
-}
-
-.progress-bar-fill {
-  height: 100%;
-  background-color: var(--color-primary);
-  border-radius: var(--radius-sm);
-  transition: width var(--transition-slow);
-}
-
-.progress-bar-fill.indeterminate {
-  width: 30%;
-  animation: indeterminate 1.5s ease-in-out infinite;
-}
-
-/* Spinner */
-.spinner {
-  width: 20px;
-  height: 20px;
-  border: 2px solid var(--color-border);
-  border-top-color: var(--color-primary);
+.tag .dot {
+  display: inline-block;
+  width: 6px; height: 6px;
   border-radius: 50%;
-  animation: spin 0.6s linear infinite;
+  background: currentColor;
 }
 
-.spinner-large {
-  width: 40px;
-  height: 40px;
-  border-width: 3px;
-}
-
-/* Tabs */
-.tabs {
-  display: flex;
-  gap: var(--spacing-sm);
-  border-bottom: 1px solid var(--color-border);
-  margin-bottom: var(--spacing-lg);
-}
-
-.tab {
-  padding: var(--spacing-sm) var(--spacing-md);
-  background-color: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  color: var(--color-text-secondary);
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-medium);
-  cursor: pointer;
-  transition: all var(--transition-normal);
-}
-
-.tab:hover {
-  color: var(--color-text-primary);
-}
-
-.tab.active {
-  color: var(--color-primary);
-  border-bottom-color: var(--color-primary);
-}
-
-/* Divider */
-.divider {
-  height: 1px;
-  background-color: var(--color-divider);
-  margin: var(--spacing-lg) 0;
-}
-
-/* Grid Layouts */
-.grid {
-  display: grid;
-  gap: var(--spacing-md);
-}
-
-.grid-2 {
-  grid-template-columns: repeat(2, 1fr);
-}
-
-.grid-3 {
-  grid-template-columns: repeat(3, 1fr);
-}
-
-.grid-4 {
-  grid-template-columns: repeat(4, 1fr);
-}
-
-@media (max-width: 768px) {
-  .grid-2, .grid-3, .grid-4 {
-    grid-template-columns: 1fr;
-  }
-}
-
-/* List */
-.list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.list-item {
-  padding: var(--spacing-md);
-  background-color: var(--color-surface);
-  border-radius: var(--radius-md);
-  margin-bottom: var(--spacing-sm);
-  transition: all var(--transition-normal);
-}
-
-.list-item:hover {
-  background-color: var(--color-surface-elevated);
-  transform: translateX(4px);
-}
-
-/* Empty State */
-.empty-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: var(--spacing-3xl) var(--spacing-xl);
-  text-align: center;
-}
-
-.empty-state-icon {
-  font-size: 64px;
-  color: var(--color-text-tertiary);
-  margin-bottom: var(--spacing-lg);
-  opacity: 0.5;
-}
-
-.empty-state-title {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
-  margin-bottom: var(--spacing-sm);
-}
-
-.empty-state-description {
-  font-size: var(--font-size-base);
-  color: var(--color-text-secondary);
-  max-width: 400px;
-  margin-bottom: var(--spacing-lg);
-}
-
-/* Toast/Alert */
-.toast {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-md);
-  padding: var(--spacing-md) var(--spacing-lg);
-  background-color: var(--color-surface-elevated);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-lg);
-  border-left: 4px solid var(--color-primary);
-}
-
-.toast-success {
-  border-left-color: var(--color-success);
-}
-
-.toast-warning {
-  border-left-color: var(--color-warning);
-}
-
-.toast-error {
-  border-left-color: var(--color-error);
-}
-
-.toast-icon {
-  flex-shrink: 0;
-  font-size: 20px;
-}
-
-.toast-content {
-  flex: 1;
-}
-
-.toast-title {
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
-  margin-bottom: 2px;
-}
-
-.toast-message {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-}
-
-/* Modal */
-.modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(4px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: var(--z-modal-backdrop);
-}
-
-.modal {
-  background-color: var(--color-bg);
-  border-radius: var(--radius-xl);
-  padding: var(--spacing-xl);
-  max-width: 600px;
-  width: 90%;
-  max-height: 80vh;
-  overflow-y: auto;
-  box-shadow: var(--shadow-xl);
-  z-index: var(--z-modal);
-}
-
-.modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: var(--spacing-lg);
-}
-
-.modal-title {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
-}
-
-.modal-body {
-  margin-bottom: var(--spacing-lg);
-}
-
-.modal-footer {
-  display: flex;
-  gap: var(--spacing-sm);
-  justify-content: flex-end;
-}
-
-/* Utility Classes */
-.hidden {
-  display: none;
-}
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
+/* ——————— Progress ——————— */
+.progress {
+  position: relative;
+  height: 4px;
+  background: var(--fc-surface);
+  border: 1px solid var(--fc-border);
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  border-radius: var(--fc-radius-1);
+}
+.progress > .fill {
+  position: absolute; inset: 0 auto 0 0;
+  width: 0%;
+  background: var(--fc-accent);
+  transition: width var(--fc-t);
+}
+.progress > .fill.warn { background: var(--fc-warn); }
+.progress > .fill.err  { background: var(--fc-err); }
+
+/* ——————— Action tile — like a command in a menu ——————— */
+.tile {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: var(--fc-sp-4);
+  padding: var(--fc-sp-4) var(--fc-sp-5);
+  background: transparent;
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius-1);
+  cursor: pointer;
+  font-family: var(--fc-font-mono);
+  color: var(--fc-fg);
+  text-align: left;
+  width: 100%;
+  transition: background var(--fc-t-fast), border-color var(--fc-t-fast), transform var(--fc-t-fast);
+}
+.tile:hover {
+  background: var(--fc-surface);
+  border-color: var(--fc-fg-muted);
+}
+.tile:hover .tile-num { color: var(--fc-accent); }
+.tile:active { transform: translateX(1px); }
+
+.tile-num {
+  width: 20px; height: 20px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: var(--fc-fs-sm);
+  color: var(--fc-fg-muted);
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius-1);
+  transition: color var(--fc-t-fast);
+}
+
+.tile-body { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.tile-title {
+  font-size: var(--fc-fs);
+  color: var(--fc-fg);
+}
+.tile-title::before {
+  content: "$ ";
+  color: var(--fc-fg-dim);
+}
+.tile-desc {
+  font-size: var(--fc-fs-sm);
+  color: var(--fc-fg-muted);
   white-space: nowrap;
-  border-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ——————— Row (settings list) ——————— */
+.row {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--fc-sp-3);
+  padding: var(--fc-sp-5) 0;
+  border-bottom: 1px dashed var(--fc-border);
+}
+.row:last-child { border-bottom: none; }
+
+.row-head {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: var(--fc-sp-4);
+}
+.row-key {
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs);
+  color: var(--fc-fg);
+}
+.row-key .prefix { color: var(--fc-fg-dim); }
+.row-hint {
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs-sm);
+  color: var(--fc-fg-muted);
+}
+
+.row-control { display: flex; gap: var(--fc-sp-3); align-items: center; }
+.row-control .input { flex: 1; }
+
+.row-foot {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: var(--fc-sp-4);
+  font-size: var(--fc-fs-sm);
+  color: var(--fc-fg-muted);
+  min-height: 16px;
 }

--- a/src/webview/shared/styles/theme.css
+++ b/src/webview/shared/styles/theme.css
@@ -1,335 +1,173 @@
 /**
- * FlowCraft Theme System - Apple-inspired Design
- * Variables for consistent styling across all webviews
+ * FlowCraft — terminal/IDE-native theme.
+ * Uses VS Code's own CSS variables so the extension inherits the user's
+ * editor theme exactly. No custom palettes; accents are derived from
+ * VS Code's semantic tokens.
  */
 
 :root {
-  /* Light Theme Colors - Apple Minimalist Black/White */
-  --color-primary: #000000;
-  --color-secondary: #666666;
-  --color-success: #2c2c2c; /* Dark grey instead of green */
-  --color-warning: #666666;
-  --color-error: #000000; /* Use iconography for error, keep text black or use pattern */
-  --color-info: #000000;
+  /* Surfaces — pulled directly from the host theme */
+  --fc-bg:           var(--vscode-sideBar-background, var(--vscode-editor-background));
+  --fc-bg-alt:       var(--vscode-editor-background);
+  --fc-surface:      var(--vscode-editorWidget-background, var(--vscode-sideBar-background));
+  --fc-surface-hi:   var(--vscode-input-background);
+  --fc-border:       var(--vscode-panel-border, var(--vscode-editorWidget-border, rgba(128,128,128,0.25)));
+  --fc-border-hi:    var(--vscode-focusBorder);
 
-  --color-bg: #F5F5F7; /* Apple System Grey 6 (Light) */
-  --color-surface: #FFFFFF;
-  --color-surface-elevated: #FFFFFF;
-  --color-border: #E5E5EA; /* Apple System Grey 4 */
-  --color-divider: #C6C6C8; /* Apple System Grey 3 */
+  /* Text — derived from the current foreground so every theme stays legible */
+  --fc-fg:           var(--vscode-sideBar-foreground, var(--vscode-foreground));
+  --fc-fg-muted:     color-mix(in srgb, var(--fc-fg) 62%, transparent);
+  --fc-fg-dim:       color-mix(in srgb, var(--fc-fg) 42%, transparent);
 
-  --color-text-primary: #000000;
-  --color-text-secondary: #86868b;
-  --color-text-tertiary: #d2d2d7;
-  --color-text-inverse: #FFFFFF;
+  /* Accents — semantic tokens straight from the theme */
+  --fc-accent:       var(--vscode-textLink-foreground);
+  --fc-accent-hi:    var(--vscode-textLink-activeForeground, var(--vscode-textLink-foreground));
+  --fc-ok:           var(--vscode-testing-iconPassed, var(--vscode-charts-green, #3fb950));
+  --fc-warn:         var(--vscode-editorWarning-foreground, var(--vscode-charts-yellow, #d29922));
+  --fc-err:          var(--vscode-editorError-foreground, var(--vscode-charts-red, #f85149));
 
-  /* Spacing System */
-  --spacing-xs: 4px;
-  --spacing-sm: 8px;
-  --spacing-md: 14px; /* Slightly larger for airy feel */
-  --spacing-lg: 20px;
-  --spacing-xl: 32px;
-  --spacing-2xl: 48px;
-  --spacing-3xl: 64px;
+  /* Typography — editor font so the panel feels like part of the IDE */
+  --fc-font-mono:    var(--vscode-editor-font-family, "SF Mono", "JetBrains Mono", "Fira Code", Menlo, Consolas, monospace);
+  --fc-font-ui:      var(--vscode-font-family);
+  --fc-fs-editor:    var(--vscode-editor-font-size, 13px);
 
-  /* Typography */
-  --font-family-display: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  --font-family-body: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  --font-family-mono: "SF Mono", "Monaco", "Consolas", "Courier New", monospace;
+  --fc-fs-xs:  10px;
+  --fc-fs-sm:  11px;
+  --fc-fs:     12px;
+  --fc-fs-md:  13px;
+  --fc-fs-lg:  15px;
 
-  --font-size-xs: 11px;
-  --font-size-sm: 12px;
-  --font-size-base: 13px;
-  --font-size-md: 15px;
-  --font-size-lg: 17px;
-  --font-size-xl: 22px;
-  --font-size-2xl: 34px; /* Larger titles */
+  /* Space — dense, like a terminal pane */
+  --fc-sp-1:   2px;
+  --fc-sp-2:   4px;
+  --fc-sp-3:   6px;
+  --fc-sp-4:   8px;
+  --fc-sp-5:   12px;
+  --fc-sp-6:   16px;
+  --fc-sp-7:   24px;
+  --fc-sp-8:   32px;
 
-  --font-weight-regular: 400;
-  --font-weight-medium: 500;
-  --font-weight-semibold: 600;
-  --font-weight-bold: 700;
+  /* Corners — sharp */
+  --fc-radius-0: 0;
+  --fc-radius-1: 2px;
+  --fc-radius-2: 3px;
 
-  --line-height-tight: 1.2;
-  --line-height-normal: 1.5;
-  --line-height-relaxed: 1.7;
-
-  /* Border Radius */
-  --radius-sm: 6px;
-  --radius-md: 10px;
-  --radius-lg: 16px;
-  --radius-xl: 20px;
-  --radius-full: 9999px;
-
-  /* Shadows - Minimal */
-  --shadow-xs: 0 1px 1px rgba(0, 0, 0, 0.03);
-  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.04);
-  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.06);
-  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.08);
-  --shadow-xl: 0 16px 32px rgba(0, 0, 0, 0.1);
-
-  /* Transitions */
-  --transition-fast: 150ms ease;
-  --transition-normal: 250ms ease;
-  --transition-slow: 350ms ease;
-  --transition-very-slow: 500ms ease;
-
-  /* Z-Index */
-  --z-dropdown: 1000;
-  --z-sticky: 1020;
-  --z-fixed: 1030;
-  --z-modal-backdrop: 1040;
-  --z-modal: 1050;
-  --z-popover: 1060;
-  --z-tooltip: 1070;
+  /* Motion */
+  --fc-t-fast:   90ms ease-out;
+  --fc-t:        140ms ease-out;
 }
 
-/* Dark Theme */
-body[data-vscode-theme-kind="vscode-dark"],
-body[data-vscode-theme-kind="vscode-high-contrast"] {
-  --color-primary: #FFFFFF;
-  --color-secondary: #98989D;
-  --color-success: #FFFFFF;
-  --color-warning: #98989D;
-  --color-error: #FFFFFF;
-  --color-info: #FFFFFF;
+/* Reset */
+* { box-sizing: border-box; margin: 0; padding: 0; }
 
-  --color-bg: #000000;
-  --color-surface: #1C1C1E;
-  --color-surface-elevated: #2C2C2E;
-  --color-border: #38383A;
-  --color-divider: #48484A;
-
-  --color-text-primary: #FFFFFF;
-  --color-text-secondary: #8E8E93;
-  --color-text-tertiary: #48484A;
-  --color-text-inverse: #000000;
-
-  /* Adjust shadows for dark theme */
-  --shadow-xs: 0 1px 1px rgba(0, 0, 0, 0.5);
-  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.5);
-  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.5);
-  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
-  --shadow-xl: 0 16px 32px rgba(0, 0, 0, 0.5);
-}
-
-/* Base Styles */
-* {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
-
-html {
-  font-size: 13px;
+html, body {
+  background: var(--fc-bg);
+  color: var(--fc-fg);
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs);
+  line-height: 1.55;
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  text-rendering: geometricPrecision;
 }
 
 body {
-  font-family: var(--font-family-body);
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-regular);
-  line-height: var(--line-height-normal);
-  color: var(--color-text-primary);
-  background-color: var(--color-bg);
+  /* Solid — scanline backgrounds read as banding on light themes */
 }
 
 /* Typography */
-h1, h2, h3, h4, h5, h6 {
-  font-family: var(--font-family-display);
-  font-weight: var(--font-weight-semibold);
-  line-height: var(--line-height-tight);
-  color: var(--color-text-primary);
-  margin: 0;
+h1, h2, h3, h4 {
+  font-family: var(--fc-font-mono);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--fc-fg);
 }
 
-h1 {
-  font-size: var(--font-size-2xl);
-  font-weight: var(--font-weight-bold);
-}
+h1 { font-size: var(--fc-fs-lg); text-transform: lowercase; }
+h2 { font-size: var(--fc-fs-md); }
+h3 { font-size: var(--fc-fs);    }
 
-h2 {
-  font-size: var(--font-size-xl);
-}
+p  { margin: 0; color: var(--fc-fg); }
 
-h3 {
-  font-size: var(--font-size-lg);
-}
-
-h4 {
-  font-size: var(--font-size-md);
-}
-
-p {
-  margin: 0;
-}
-
-/* Links */
 a {
-  color: var(--color-primary);
+  color: var(--fc-accent);
   text-decoration: none;
-  transition: opacity var(--transition-fast);
+  border-bottom: 1px dashed transparent;
+  transition: border-color var(--fc-t-fast);
+}
+a:hover, a:focus-visible {
+  border-bottom-color: var(--fc-accent);
+  outline: none;
 }
 
-a:hover {
-  opacity: 0.8;
+code, kbd, pre {
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs-sm);
 }
 
-a:active {
-  opacity: 0.6;
-}
-
-/* Code */
-code, pre {
-  font-family: var(--font-family-mono);
-  font-size: var(--font-size-sm);
-}
-
-code {
-  padding: 2px 4px;
-  background-color: var(--color-surface);
-  border-radius: var(--radius-sm);
-}
-
-pre {
-  padding: var(--spacing-md);
-  background-color: var(--color-surface);
-  border-radius: var(--radius-md);
-  overflow-x: auto;
-}
-
-pre code {
-  padding: 0;
-  background-color: transparent;
-}
-
-/* Scrollbar */
-::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
-}
-
-::-webkit-scrollbar-track {
-  background: var(--color-bg);
-}
-
+/* Scrollbar — thin, flat */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb {
-  background: var(--color-border);
-  border-radius: var(--radius-full);
+  background: var(--fc-border);
+  border-radius: 0;
 }
-
-::-webkit-scrollbar-thumb:hover {
-  background: var(--color-text-secondary);
-}
+::-webkit-scrollbar-thumb:hover { background: var(--fc-fg-muted); }
 
 /* Selection */
 ::selection {
-  background-color: var(--color-primary);
-  color: var(--color-text-inverse);
-  opacity: 0.3;
+  background: var(--vscode-editor-selectionBackground, var(--fc-accent));
+  color: var(--vscode-editor-selectionForeground, var(--fc-fg));
 }
 
 /* Focus */
 :focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
+  outline: 1px solid var(--fc-border-hi);
+  outline-offset: 1px;
 }
 
 /* Disabled */
-:disabled {
-  opacity: 0.5;
+:disabled, [disabled] {
+  opacity: 0.45;
   cursor: not-allowed;
 }
 
-/* Utility Classes */
-.text-primary {
-  color: var(--color-text-primary);
+/* ——————— Utility ——————— */
+.hidden { display: none !important; }
+
+.mono { font-family: var(--fc-font-mono); }
+.muted { color: var(--fc-fg-muted); }
+.dim   { color: var(--fc-fg-dim); }
+.ok    { color: var(--fc-ok); }
+.warn  { color: var(--fc-warn); }
+.err   { color: var(--fc-err); }
+
+.flex         { display: flex; }
+.col          { flex-direction: column; }
+.items-center { align-items: center; }
+.between      { justify-content: space-between; }
+.gap-1        { gap: var(--fc-sp-2); }
+.gap-2        { gap: var(--fc-sp-4); }
+.gap-3        { gap: var(--fc-sp-5); }
+
+/* Hairline rule, like a TUI box edge */
+.rule {
+  height: 1px;
+  background: var(--fc-border);
+  margin: var(--fc-sp-5) 0;
 }
 
-.text-secondary {
-  color: var(--color-text-secondary);
+/* Section marker: `// foo` style heading */
+.section-marker {
+  display: block;
+  font-size: var(--fc-fs-sm);
+  color: var(--fc-fg-muted);
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+  padding: var(--fc-sp-2) 0;
+  border-bottom: 1px dashed var(--fc-border);
+  margin-bottom: var(--fc-sp-4);
 }
-
-.text-tertiary {
-  color: var(--color-text-tertiary);
+.section-marker::before {
+  content: "// ";
+  color: var(--fc-fg-dim);
 }
-
-.text-success {
-  color: var(--color-success);
-}
-
-.text-warning {
-  color: var(--color-warning);
-}
-
-.text-error {
-  color: var(--color-error);
-}
-
-.bg-surface {
-  background-color: var(--color-surface);
-}
-
-.bg-elevated {
-  background-color: var(--color-surface-elevated);
-}
-
-/* Layout Utilities */
-.container {
-  width: 100%;
-  padding: var(--spacing-lg);
-}
-
-.flex {
-  display: flex;
-}
-
-.flex-col {
-  display: flex;
-  flex-direction: column;
-}
-
-.items-center {
-  align-items: center;
-}
-
-.justify-center {
-  justify-content: center;
-}
-
-.justify-between {
-  justify-content: space-between;
-}
-
-.gap-xs { gap: var(--spacing-xs); }
-.gap-sm { gap: var(--spacing-sm); }
-.gap-md { gap: var(--spacing-md); }
-.gap-lg { gap: var(--spacing-lg); }
-.gap-xl { gap: var(--spacing-xl); }
-
-/* Spacing Utilities */
-.p-xs { padding: var(--spacing-xs); }
-.p-sm { padding: var(--spacing-sm); }
-.p-md { padding: var(--spacing-md); }
-.p-lg { padding: var(--spacing-lg); }
-.p-xl { padding: var(--spacing-xl); }
-
-.m-xs { margin: var(--spacing-xs); }
-.m-sm { margin: var(--spacing-sm); }
-.m-md { margin: var(--spacing-md); }
-.m-lg { margin: var(--spacing-lg); }
-.m-xl { margin: var(--spacing-xl); }
-
-/* Border Radius Utilities */
-.rounded-sm { border-radius: var(--radius-sm); }
-.rounded-md { border-radius: var(--radius-md); }
-.rounded-lg { border-radius: var(--radius-lg); }
-.rounded-xl { border-radius: var(--radius-xl); }
-.rounded-full { border-radius: var(--radius-full); }
-
-/* Shadow Utilities */
-.shadow-sm { box-shadow: var(--shadow-sm); }
-.shadow-md { box-shadow: var(--shadow-md); }
-.shadow-lg { box-shadow: var(--shadow-lg); }
-.shadow-xl { box-shadow: var(--shadow-xl); }

--- a/src/webview/welcome/index.html
+++ b/src/webview/welcome/index.html
@@ -4,105 +4,111 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src {{cspSource}} 'unsafe-inline'; script-src 'nonce-{{nonce}}'; img-src {{cspSource}} https: data:;">
-    <title>FlowCraft Welcome</title>
-    
+    <title>FlowCraft</title>
+
     <link rel="stylesheet" href="{{themeCss}}">
     <link rel="stylesheet" href="{{componentsCss}}">
     <link rel="stylesheet" href="{{welcomeCss}}">
     <link rel="stylesheet" href="{{codiconCss}}">
 </head>
 <body>
-    <div class="welcome-container">
-        <div class="header">
-            <div class="logo-container">
-                <!-- Placeholder for logo, could be an SVG or img -->
-                <svg class="logo animate-bounce" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
-                    <defs>
-                        <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
-                            <stop offset="0%" style="stop-color:#007AFF;stop-opacity:1" />
-                            <stop offset="100%" style="stop-color:#5856D6;stop-opacity:1" />
-                        </linearGradient>
-                    </defs>
-                    <rect x="32" y="32" width="80" height="80" rx="16" fill="url(#grad)" />
-                    <circle cx="184" cy="72" r="40" fill="url(#grad)" opacity="0.8" />
-                    <polygon points="128,144 48,224 208,224" fill="url(#grad)" opacity="0.9" />
-                </svg>
-            </div>
-            <h1>FlowCraft</h1>
-            <p class="subtitle">AI-Powered Diagram Generator</p>
-        </div>
+    <main class="wc">
 
-        <div class="usage-section">
-            <div class="usage-header">
-                <span class="usage-title">Subscription</span>
-                <div id="subscription-badge">
-                    <span class="badge badge-secondary">Free</span>
-                </div>
+        <header class="wc-head">
+            <div class="wc-prompt">
+                <span class="wc-prompt-user">flowcraft</span><span class="wc-prompt-sep">@</span><span class="wc-prompt-host">vscode</span>
+                <span class="wc-prompt-path">~/diagrams</span>
+                <span class="wc-prompt-caret">$</span>
             </div>
-            <div class="progress-bar" id="usage-progress">
-                <div class="progress-bar-fill" id="usage-fill" style="width: 0%"></div>
-            </div>
-            <div class="usage-header" style="margin-top: 8px; margin-bottom: 0;">
-                <span class="usage-limit" id="usage-text">Loading usage...</span>
-                <span class="usage-limit" id="usage-limit"></span>
-            </div>
-        </div>
+            <div class="wc-version muted">v2.1.0</div>
+        </header>
 
-        <div class="action-grid">
-            <div class="action-card" id="action-diagram">
-                <div class="action-card-icon">
-                    <i class="codicon codicon-graph"></i>
-                </div>
-                <div class="action-card-title">Diagram</div>
-                <div class="action-card-subtitle">Flowchart, Sequence...</div>
+        <section class="wc-status" aria-label="subscription status">
+            <div class="wc-status-row">
+                <span class="wc-status-label">plan</span>
+                <span id="subscription-badge" class="tag"><span class="dot"></span>free</span>
             </div>
-            
-            <div class="action-card" id="action-infographic">
-                <div class="action-card-icon">
-                    <i class="codicon codicon-dashboard"></i>
-                </div>
-                <div class="action-card-title">Infographic</div>
-                <div class="action-card-subtitle">Visual Data</div>
+            <div class="progress" id="usage-progress" aria-hidden="false">
+                <div class="fill" id="usage-fill" style="width: 0%"></div>
             </div>
-
-            <div class="action-card" id="action-image">
-                <div class="action-card-icon">
-                    <i class="codicon codicon-file-media"></i>
-                </div>
-                <div class="action-card-title">Image</div>
-                <div class="action-card-subtitle">AI Illustration</div>
+            <div class="wc-status-row wc-status-foot">
+                <span id="usage-text" class="mono muted">—</span>
+                <span id="usage-limit" class="mono muted"></span>
             </div>
+        </section>
 
-            <div class="action-card" id="action-history">
-                <div class="action-card-icon">
-                    <i class="codicon codicon-history"></i>
-                </div>
-                <div class="action-card-title">History</div>
-                <div class="action-card-subtitle">Past Visuals</div>
-            </div>
-        </div>
+        <span class="section-marker">actions</span>
 
-        <div class="divider"></div>
+        <nav class="wc-actions" aria-label="commands">
+            <button class="tile" id="action-diagram" data-key="1">
+                <span class="tile-num">1</span>
+                <span class="tile-body">
+                    <span class="tile-title">generate diagram</span>
+                    <span class="tile-desc">flowchart · sequence · class · er · …</span>
+                </span>
+                <span class="kbd">⌘⇧D</span>
+            </button>
 
-        <div class="quick-links">
-            <a href="#" class="link-item" id="link-settings">
-                <i class="codicon codicon-settings-gear link-icon"></i>
-                <span>Settings & API Keys</span>
-            </a>
-            <a href="https://flowcraft.app/docs" class="link-item">
-                <i class="codicon codicon-book link-icon"></i>
-                <span>Documentation</span>
-            </a>
-            <a href="https://github.com/flowcraft/vscode/issues" class="link-item">
-                <i class="codicon codicon-github-action link-icon"></i>
-                <span>Report Issue</span>
-            </a>
-        </div>
+            <button class="tile" id="action-selection" data-key="2">
+                <span class="tile-num">2</span>
+                <span class="tile-body">
+                    <span class="tile-title">from selection</span>
+                    <span class="tile-desc">use the highlighted text in the editor</span>
+                </span>
+                <span class="kbd">⌘⇧G</span>
+            </button>
 
-        <div class="footer">
-            <p>v2.0.0 • FlowCraft Inc.</p>
-        </div>
-    </div>
+            <button class="tile" id="action-infographic" data-key="3">
+                <span class="tile-num">3</span>
+                <span class="tile-body">
+                    <span class="tile-title">infographic <span class="tag">soon</span></span>
+                    <span class="tile-desc">visual data summary</span>
+                </span>
+                <span class="kbd">—</span>
+            </button>
+
+            <button class="tile" id="action-image" data-key="4">
+                <span class="tile-num">4</span>
+                <span class="tile-body">
+                    <span class="tile-title">illustration <span class="tag">soon</span></span>
+                    <span class="tile-desc">ai-rendered image</span>
+                </span>
+                <span class="kbd">—</span>
+            </button>
+
+            <button class="tile" id="action-history" data-key="5">
+                <span class="tile-num">5</span>
+                <span class="tile-body">
+                    <span class="tile-title">history</span>
+                    <span class="tile-desc">previously generated diagrams</span>
+                </span>
+                <span class="kbd">⌘H</span>
+            </button>
+        </nav>
+
+        <span class="section-marker">shortcuts</span>
+
+        <ul class="wc-links">
+            <li><a href="#" id="link-settings" class="wc-link">
+                <span class="wc-link-caret">›</span> settings &amp; api keys
+                <span class="kbd">⌘,</span>
+            </a></li>
+            <li><a href="https://flowcraft.app/docs" class="wc-link">
+                <span class="wc-link-caret">›</span> docs
+                <span class="muted">flowcraft.app/docs</span>
+            </a></li>
+            <li><a href="https://github.com/flowcraft/vscode/issues" class="wc-link">
+                <span class="wc-link-caret">›</span> report issue
+                <span class="muted">github</span>
+            </a></li>
+        </ul>
+
+        <footer class="wc-foot">
+            <span class="wc-foot-cell"><span class="dim">STATUS</span> <span id="foot-status" class="ok">ready</span></span>
+            <span class="wc-foot-cell"><span class="dim">MODE</span> <span id="foot-mode">byok</span></span>
+            <span class="wc-foot-cell"><span class="dim">TIP</span> press <kbd>1</kbd>–<kbd>5</kbd> or <kbd>⌘⇧P</kbd> → flowcraft</span>
+        </footer>
+    </main>
 
     <script type="module" nonce="{{nonce}}" src="{{welcomeJs}}"></script>
 </body>

--- a/src/webview/welcome/welcome.css
+++ b/src/webview/welcome/welcome.css
@@ -1,110 +1,139 @@
-/* Welcome View Specific Styles */
+/* Welcome — terminal-pane layout */
 
-body {
-  padding: 0;
-  overflow-x: hidden;
-}
+body { padding: 0; overflow-x: hidden; }
 
-.welcome-container {
-  padding: var(--spacing-lg);
-  max-width: 100%;
-}
-
-.header {
-  margin-bottom: var(--spacing-xl);
-  text-align: center;
-}
-
-.logo {
-  width: 64px;
-  height: 64px;
-  margin-bottom: var(--spacing-md);
-}
-
-.subtitle {
-  font-size: var(--font-size-md);
-  color: var(--color-text-secondary);
-  margin-top: var(--spacing-xs);
-}
-
-.action-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: var(--spacing-md);
-  margin-bottom: var(--spacing-xl);
-}
-
-.usage-section {
-  background-color: var(--color-surface);
-  border-radius: var(--radius-lg);
-  padding: var(--spacing-lg);
-  margin-bottom: var(--spacing-xl);
-  border: 1px solid var(--color-border);
-}
-
-.usage-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: var(--spacing-md);
-}
-
-.usage-title {
-  font-weight: var(--font-weight-semibold);
-  font-size: var(--font-size-md);
-}
-
-.usage-limit {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-}
-
-.quick-links {
+.wc {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-sm);
+  gap: var(--fc-sp-6);
+  padding: var(--fc-sp-5);
+  min-height: 100vh;
 }
 
-.link-item {
+/* Prompt line ——————————————————————————— */
+.wc-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--fc-sp-4);
+  padding-bottom: var(--fc-sp-4);
+  border-bottom: 1px dashed var(--fc-border);
+}
+.wc-prompt {
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs-md);
+  color: var(--fc-fg);
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.wc-prompt-user { color: var(--fc-accent); }
+.wc-prompt-sep  { color: var(--fc-fg-dim); }
+.wc-prompt-host { color: var(--fc-fg-muted); }
+.wc-prompt-path { color: var(--fc-fg-muted); margin-left: var(--fc-sp-3); }
+.wc-prompt-caret {
+  color: var(--fc-accent);
+  margin-left: var(--fc-sp-3);
+  animation: wc-blink 1.1s steps(1) infinite;
+}
+@keyframes wc-blink { 50% { opacity: 0; } }
+
+.wc-version {
+  font-size: var(--fc-fs-sm);
+  font-family: var(--fc-font-mono);
+}
+
+/* Status block ——————————————————————————— */
+.wc-status {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fc-sp-3);
+  padding: var(--fc-sp-4) var(--fc-sp-5);
+  background: var(--fc-surface);
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius-1);
+}
+.wc-status-row {
   display: flex;
   align-items: center;
-  gap: var(--spacing-sm);
-  padding: var(--spacing-sm) var(--spacing-md);
-  border-radius: var(--radius-md);
-  color: var(--color-text-primary);
-  transition: background-color var(--transition-fast);
+  justify-content: space-between;
+  gap: var(--fc-sp-4);
+}
+.wc-status-label {
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs-sm);
+  color: var(--fc-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.wc-status-foot { font-size: var(--fc-fs-sm); }
+
+/* Actions ——————————————————————————— */
+.wc-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fc-sp-3);
 }
 
-.link-item:hover {
-  background-color: var(--color-surface);
-  text-decoration: none;
+/* Links list ——————————————————————————— */
+.wc-links {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--fc-sp-1);
+}
+.wc-link {
+  display: flex;
+  align-items: center;
+  gap: var(--fc-sp-3);
+  padding: var(--fc-sp-2) var(--fc-sp-3);
+  font-family: var(--fc-font-mono);
+  font-size: var(--fc-fs);
+  color: var(--fc-fg);
+  border: 1px solid transparent;
+  border-radius: var(--fc-radius-1);
+}
+.wc-link:hover {
+  background: var(--fc-surface);
+  border-color: var(--fc-border);
+  border-bottom-color: var(--fc-border); /* override anchor dashed underline */
+}
+.wc-link-caret { color: var(--fc-fg-dim); }
+.wc-link .kbd, .wc-link .muted { margin-left: auto; }
+
+/* Status line (terminal footer) ——————————————————— */
+.wc-foot {
+  margin-top: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--fc-sp-5);
+  padding: var(--fc-sp-3) var(--fc-sp-4);
+  font-family: var(--fc-font-mono);
+  font-size: 10px;
+  color: var(--fc-fg-muted);
+  background: var(--fc-surface);
+  border: 1px solid var(--fc-border);
+  border-radius: var(--fc-radius-1);
+  letter-spacing: 0.04em;
+}
+.wc-foot .dim { color: var(--fc-fg-dim); margin-right: 4px; }
+.wc-foot-cell { display: inline-flex; align-items: center; gap: 4px; }
+.wc-foot kbd { font-size: 9px; padding: 0 4px; }
+
+/* Entrance — one subtle, staggered reveal */
+.wc-head     { animation: wc-in 220ms ease-out both; }
+.wc-status   { animation: wc-in 220ms ease-out 40ms  both; }
+.wc-actions  { animation: wc-in 220ms ease-out 80ms  both; }
+.wc-links    { animation: wc-in 220ms ease-out 120ms both; }
+.wc-foot     { animation: wc-in 220ms ease-out 160ms both; }
+
+@keyframes wc-in {
+  from { opacity: 0; transform: translateY(3px); }
+  to   { opacity: 1; transform: none; }
 }
 
-.link-icon {
-  font-size: 16px;
-  color: var(--color-text-secondary);
-}
-
-.footer {
-  margin-top: var(--spacing-2xl);
-  text-align: center;
-  font-size: var(--font-size-xs);
-  color: var(--color-text-tertiary);
-}
-
-/* Animations */
-.header {
-  animation: slideInDown var(--transition-normal);
-}
-
-.action-grid {
-  animation: scaleIn var(--transition-normal) 0.1s backwards;
-}
-
-.usage-section {
-  animation: slideInUp var(--transition-normal) 0.2s backwards;
-}
-
-.quick-links {
-  animation: slideInUp var(--transition-normal) 0.3s backwards;
+@media (prefers-reduced-motion: reduce) {
+  .wc-head, .wc-status, .wc-actions, .wc-links, .wc-foot { animation: none; }
+  .wc-prompt-caret { animation: none; opacity: 1; }
 }

--- a/src/webview/welcome/welcome.js
+++ b/src/webview/welcome/welcome.js
@@ -1,81 +1,92 @@
 import { postMessage, onMessage } from '../shared/utils/messaging.js';
-import { getById, setInnerHTML, addClasses, removeClasses } from '../shared/utils/dom.js';
+import { getById } from '../shared/utils/dom.js';
 
-// Initialize
+const ACTIONS = [
+  { id: 'action-diagram',     command: 'generateDiagram' },
+  { id: 'action-selection',   command: 'generateFromSelection' },
+  { id: 'action-infographic', command: 'createInfographic' },
+  { id: 'action-image',       command: 'generateImage' },
+  { id: 'action-history',     command: 'viewHistory' },
+];
+
 document.addEventListener('DOMContentLoaded', () => {
-  // Request initial data
   postMessage('checkUsage');
+  wireActions();
+  wireShortcuts();
+  wireLinks();
 
-  // Set up event listeners
-  setupEventListeners();
-
-  // Set up message listeners
-  onMessage({
-    updateUsage: handleUpdateUsage
-  });
+  onMessage({ updateUsage: renderUsage });
 });
 
-function setupEventListeners() {
-  // Action Cards
-  const actions = [
-    { id: 'action-diagram', command: 'generateDiagram' },
-    { id: 'action-infographic', command: 'createInfographic' },
-    { id: 'action-image', command: 'generateImage' },
-    { id: 'action-history', command: 'viewHistory' }
-  ];
+function wireActions() {
+  for (const { id, command } of ACTIONS) {
+    const el = getById(id);
+    if (!el) continue;
+    el.addEventListener('click', () => postMessage(command));
+  }
+}
 
-  actions.forEach(({ id, command }) => {
-    const element = getById(id);
-    if (element) {
-      element.addEventListener('click', () => {
-        postMessage(command);
-      });
+function wireShortcuts() {
+  // Press 1–5 to trigger the matching tile. Ignore when typing in an input.
+  document.addEventListener('keydown', (e) => {
+    const tag = (e.target && e.target.tagName) || '';
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || e.metaKey || e.ctrlKey || e.altKey) return;
+    const idx = parseInt(e.key, 10);
+    if (!Number.isInteger(idx) || idx < 1 || idx > ACTIONS.length) return;
+    const { command } = ACTIONS[idx - 1];
+    postMessage(command);
+    const tile = getById(ACTIONS[idx - 1].id);
+    if (tile) {
+      tile.animate(
+        [{ background: 'var(--fc-surface-hi)' }, { background: 'transparent' }],
+        { duration: 220, easing: 'ease-out' }
+      );
     }
   });
+}
 
-  // Quick Links
-  const settingsLink = getById('link-settings');
-  if (settingsLink) {
-    settingsLink.addEventListener('click', (e) => {
+function wireLinks() {
+  const settings = getById('link-settings');
+  if (settings) {
+    settings.addEventListener('click', (e) => {
       e.preventDefault();
       postMessage('openSettings');
     });
   }
 }
 
-function handleUpdateUsage(usage) {
-  const progressBar = getById('usage-progress');
-  const progressFill = getById('usage-fill');
-  const usageText = getById('usage-text');
-  const limitText = getById('usage-limit');
-  const badgeContainer = getById('subscription-badge');
-
+function renderUsage(usage) {
   if (!usage) return;
 
-  // Update subscription status
+  const progress  = getById('usage-progress');
+  const fill      = getById('usage-fill');
+  const text      = getById('usage-text');
+  const limit     = getById('usage-limit');
+  const badge     = getById('subscription-badge');
+  const footMode  = getById('foot-mode');
+
   if (usage.subscribed) {
-    badgeContainer.innerHTML = '<span class="badge badge-success">Pro</span>';
-    limitText.textContent = 'Unlimited';
-    if (progressBar) progressBar.style.display = 'none';
-    usageText.textContent = `${usage.diagramsCreated} diagrams created`;
+    badge.className = 'tag tag-pro';
+    badge.innerHTML = '<span class="dot"></span>pro';
+    if (progress) progress.classList.add('hidden');
+    text.textContent  = `${usage.diagramsCreated} diagrams generated`;
+    limit.textContent = '∞';
+    if (footMode) footMode.textContent = 'pro';
   } else {
-    badgeContainer.innerHTML = '<span class="badge badge-secondary">Free</span>';
-    limitText.textContent = `${usage.freeLimit} limit`;
+    badge.className = 'tag';
+    badge.innerHTML = '<span class="dot"></span>free';
+    if (progress) progress.classList.remove('hidden');
 
-    // Update progress bar
-    const percentage = Math.min(100, (usage.diagramsCreated / usage.freeLimit) * 100);
-    if (progressFill) {
-      progressFill.style.width = `${percentage}%`;
-
-      // Color coding
-      removeClasses(progressFill, 'bg-warning', 'bg-error');
-      if (percentage >= 90) {
-        addClasses(progressFill, 'bg-error');
-      } else if (percentage >= 70) {
-        addClasses(progressFill, 'bg-warning');
-      }
+    const pct = Math.min(100, (usage.diagramsCreated / usage.freeLimit) * 100);
+    if (fill) {
+      fill.style.width = `${pct}%`;
+      fill.classList.remove('warn', 'err');
+      if (pct >= 90)      fill.classList.add('err');
+      else if (pct >= 70) fill.classList.add('warn');
     }
 
-    usageText.textContent = `${usage.diagramsCreated} / ${usage.freeLimit}`;
+    text.textContent  = `[${usage.diagramsCreated}/${usage.freeLimit}] diagrams`;
+    limit.textContent = `${Math.max(0, usage.freeLimit - usage.diagramsCreated)} left`;
+    if (footMode) footMode.textContent = 'byok';
   }
 }


### PR DESCRIPTION
## Summary
- Welcome + Settings webviews rebuilt with a terminal/IDE-native aesthetic on top of VS Code's own theme variables — inherits whatever editor theme the user has enabled. Welcome gets a prompt-line header, numbered action tiles with 1–5 hotkeys, kbd hints, TUI status-line footer. Settings reads like a `settings.toml` file with ⌘S save / ⌘R reset, reveal-keys toggle, inline provider test buttons.
- Command UX: diagram QuickPick is now categorized (Software / Planning / Advanced) with codicon glyphs and filter-on-description. Input-method picker reordered (Selection → File → Pick → Paste) with richer descriptions. Progress notifications now show stepped messages instead of a silent percent.
- Error handling: new `humanizeError()` parses `litellm.RateLimitError`, quota, 401/403, timeout, etc. into short, readable toasts with actionable buttons. Rate-limit errors now offer **Open Billing** (routes to the right provider's billing page), **Switch Provider**, **Retry**.
- Fixes a pre-existing TS2345 in `src/utils/file-utils.ts` by switching `Buffer.from` to `TextEncoder` so `vscode.workspace.fs.writeFile` accepts the payload.
- Light-theme fix: `--fc-fg-dim` / `--fc-fg-muted` now derive from the current foreground via `color-mix()` instead of `--vscode-disabledForeground` (near-invisible on light themes). Removed body scanline gradient that banded on light backgrounds.

## Test plan
- [ ] F5 → Extension Development Host; Welcome panel renders, keybindings 1–5 trigger matching actions, ⌘⇧D opens generation
- [ ] Swap to a light theme (Light+, Quiet Light, Solarized Light) — confirm all text is legible, no banding
- [ ] Swap to a dark theme (Dark+, Dracula) — confirm accents and status dots still pop
- [ ] Settings panel: ⌘S saves, ⌘R resets, eye icon toggles password reveal, Test button shows `● checking… → ● verified`
- [ ] Run `flowcraft.openGenerationView` → quick-pick shows category separators and codicons; pick a type → input-method picker appears; pick Current Selection → progress shows stepped messages
- [ ] Simulate a rate-limit (use an OpenAI key with no quota) → toast reads "Provider quota exceeded · …" with Open Billing / Switch Provider / Retry
- [ ] `tsc -p ./` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)