### PR TITLE
feat: per-provider model selection + refreshed webviews

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+VS Code extension that generates Mermaid diagrams (and upcoming infographics/images) from code selections or prompts, published as `FlowCraft.flowcraft` on the Marketplace. It is one of three sibling projects in the FlowcraftProject monorepo — see the parent `../CLAUDE.md` for how it relates to the `FlowCraft` Next.js app and `flowcraft-api` FastAPI backend.
+
+## Commands
+
+```bash
+npm install                 # package-lock.json is the lockfile
+npm run compile             # tsc -p ./  (emits to out/)
+npm run watch               # tsc -w
+npm run lint                # eslint src --ext ts
+npm run test                # vscode-test (runs .test.ts under src/test/)
+node scripts/copy-webview-files.js   # copy src/webview/* → media/webview/*
+npx vsce package            # build .vsix
+```
+
+Note: `scripts.vscode:prepublish` and `scripts.pretest` invoke `pnpm run …`. Use pnpm if you hit lockfile drift, otherwise invoke the underlying commands directly (`tsc -p ./`, `node scripts/copy-webview-files.js`) — webview HTML/CSS/JS **must** be copied into `media/webview/` before the extension is loaded, because webview providers load assets from `media/`, not `src/`.
+
+Launch locally: press **F5** in VS Code to open an Extension Development Host with this extension loaded.
+
+## Architecture
+
+### Activation flow (`src/extension.ts`)
+
+`activate()` wires up the object graph in this order, and new features should follow the same pattern:
+
+1. `initLogger("FlowCraft")` — global output channel logger (`src/utils/logger.ts`).
+2. `StateManager` (`src/state/state-manager.ts`) — persists to `context.globalState`; composes `DiagramStore`, `SettingsStore`, `UsageStore` and emits change events to listeners.
+3. `APIKeyService` — wraps `context.secrets` with per-provider keys prefixed `flowcraft.apikey.<provider>`; `migrateOldKeys()` converts legacy single-provider storage on startup.
+4. `FlowCraftClient` (`src/api/flowcraft-client.ts`) — talks to the FlowCraft API (`https://flowcraft-api-cb66lpneaq-ue.a.run.app` by default, overridable via `FLOWCRAFT_API_URL` env var). Handles retries, timeouts, and maps typed errors from `src/api/errors.ts`.
+5. `UsageService`, `DiagramService` — orchestrate client + state + secrets.
+6. `WelcomeViewProvider`, `SettingsViewProvider` — register sidebar webviews under the `flowcraft` activity-bar container.
+7. Commands are registered individually and pushed to `context.subscriptions`. The chat participant `flowcraft.diagramAssistant` is wired through `ChatParticipantHandler.ts`.
+
+### Multi-provider API key model (critical)
+
+The extension is BYOK. The default provider comes from the setting `flowcraft.api.provider` (enum: `openai` | `anthropic` | `google` | `flowcraft`). The flow used by every generation command is `ensureProviderApiKey(stateManager, apiKeyService)`:
+
+1. Read `defaultProvider` from `StateManager.getSetting("defaultProvider")`.
+2. Look up a stored key for that provider via `APIKeyService.retrieve(provider)`.
+3. If missing, prompt with a provider-specific `InputBox` whose `validateInput` enforces that provider's prefix (`sk-`, `sk-ant-`, etc.), then `store()` it.
+
+**v2.1.0 fix context:** earlier versions only checked the OpenAI key regardless of the configured provider — any new code path that calls the API must route through `ensureProviderApiKey` (or equivalent), not read an OpenAI key directly. The legacy `OPENAI_KEY_SECRET = "flowcraft.openai.key"` constant is retained only for the `flowcraft.resetApiKey` command and migration.
+
+### API endpoints used
+
+- `POST {FLOWCRAFT_API_URL}/diagrams/generate` — v1, used by the legacy flow/class diagram commands.
+- `POST {FLOWCRAFT_API_URL}/v2/diagrams/generate` — v2, used by `flowcraft.openGenerationView`. Returns `response.mermaid_code` and `response.inserted_diagram.data[0].id`; the extension opens `https://flowcraft.app/vscode/<id>` in the user's browser rather than rendering inline.
+
+Authentication header is `X-api-key: <user's provider key>` — the FlowCraft API accepts third-party provider keys directly and fans out to the right LLM via LiteLLM.
+
+### Per-provider model selection
+
+Each generation request carries an optional `model` field in the body. The value is resolved in `DiagramService.generate()` by reading `settings.providerModels[provider]` — persisted in `SettingsStore` and edited through the Settings webview's "models · per provider" section. The curated list per provider lives in two places that must stay in sync: `src/types/api.ts` (`PROVIDER_INFO.supportedModels`, used by TS code) and `src/webview/settings/settings.js` (`MODELS_BY_PROVIDER`, used by the webview dropdown). When `providerModels[provider]` is unset, the field is omitted from the request body and the API falls back to its env-provided default.
+
+### Webviews (`src/webview/` ↔ `media/webview/`)
+
+Source HTML/CSS/JS lives under `src/webview/{welcome,settings,generation,history,viewer,shared}/`. TypeScript is compiled to `out/`, but webview assets are plain static files and must be copied into `media/webview/` by `scripts/copy-webview-files.js` before the webview providers in `src/views/` can load them via `webview.asWebviewUri`. Webview `index.html` files expect to be served from `media/webview/<name>/`.
+
+### Extension contribution surface (`package.json`)
+
+- Activity-bar container `flowcraft` hosts two webview views: `flowcraft.welcomeView` and `flowcraft.settingsView`.
+- Two keybindings: `cmd+shift+d` → open generation view; `cmd+shift+g` → generate from selection.
+- Context-menu entries on `editor/context` and `explorer/context` dispatch to `flowcraft.generateFromSelection` / `flowcraft.generateFromFile`, which in turn execute the v1 `generateFlowDiagram*` commands.
+- Chat participant `flowcraft.diagramAssistant` exposes slash commands (`/flowchart`, `/sequence`, `/classDiagram`, `/stateDiagram`, `/erDiagram`, `/explainDiagram`) — implemented in `src/ChatParticipantHandler.ts`.
+- Configuration schema under `flowcraft.*` defines provider, diagram defaults, cache TTL, request timeout, concurrency limits.
+
+### Size limits
+
+All generation paths hard-cap input at **10,000 characters** and reject empty input. If you add a new generation command, mirror this check to avoid oversized requests hitting the API.
+
+## TypeScript settings
+
+`tsconfig.json` is strict with `noUnusedLocals`, `noUnusedParameters`, `noImplicitOverride`, `noImplicitReturns`, `noFallthroughCasesInSwitch`. `rootDir: src`, `outDir: out`, module `Node16`, target `ES2022`. Tests (`**/*.test.ts`) are excluded from the compile.

--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ Transform your code into beautiful diagrams, infographics, and visualizations in
 ## Key Features
 
 ### Multi-Provider AI Support
-Choose the AI model that fits your needs and budget. FlowCraft supports:
-*   **OpenAI**
-*   **Anthropic**
-*   **Google**
-*   **FlowCraft API** 
+Choose the AI provider — and the specific model — that fits your needs and budget. FlowCraft supports:
+*   **OpenAI** — `gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo`, `o1-mini`, `o3-mini`
+*   **Anthropic** — Claude Opus 4, Sonnet 4, Haiku 4, and recent 3.x models
+*   **Google** — `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-1.5-pro`, `gemini-1.5-flash`
+*   **FlowCraft API**
     * Documentation available at [FlowCraft API Docs](https://www.flowcraft.app/features/api-keys/).
+
+Select your per-provider model from the Settings sidebar (`models · per provider`). The choice is sent with every generation request; leave on **default** to use the server-side default.
 
 ### Comprehensive Visualization Types
 Generate widespread diagram standards and creative assets:
@@ -51,10 +53,13 @@ You can generate diagrams in multiple ways:
 
 ## Configuration
 
-Access settings via `Cmd+,` (or `Ctrl+,`) and search for `FlowCraft`:
-*   `flowcraft.api.provider`: Set your default AI provider.
-*   `flowcraft.diagrams.defaultType`: Set your preferred diagram type.
-*   `flowcraft.diagrams.autoSave`: Toggle automatic saving to history.
+Open the **FlowCraft Settings** sidebar panel to configure:
+*   **Providers & keys** — paste API keys for each provider; stored in `vscode.secrets`.
+*   **Default provider** — which provider generation commands use by default.
+*   **Per-provider model** — pick the LLM for each provider (e.g. Opus 4 for Anthropic, `gpt-4o-mini` for OpenAI). Leave on `default (server)` to use FlowCraft's recommended model.
+*   **Defaults** — diagram type, color palette, complexity.
+
+Or access VS Code's settings (`Cmd+,` / `Ctrl+,`) and search for `FlowCraft` for the underlying keys.
 
 ## Contributing & Support
 

--- a/media/webview/settings/index.html
+++ b/media/webview/settings/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src {{cspSource}} 'unsafe-inline'; script-src 'nonce-{{nonce}}'; img-src {{cspSource}} https: data:;">
-    <title>FlowCraft · settings</title>
+    <title>FlowCraft · Settings</title>
 
     <link rel="stylesheet" href="{{themeCss}}">
     <link rel="stylesheet" href="{{componentsCss}}">
@@ -15,144 +15,198 @@
     <main class="st">
 
         <header class="st-head">
-            <div class="st-path">
-                <span class="muted">flowcraft</span>
-                <span class="dim">/</span>
-                <span>settings.toml</span>
+            <div class="st-head-text">
+                <h1 class="st-title">Settings</h1>
+                <p class="st-subtitle">Connect a provider and set your defaults. Your keys stay on this machine.</p>
             </div>
-            <div class="st-actions">
-                <button class="btn-icon" id="reveal-btn" title="show / hide keys">
+            <div class="st-head-actions">
+                <button class="btn-icon" id="reveal-btn" title="Show or hide API keys" aria-label="Show or hide API keys">
                     <i class="codicon codicon-eye"></i>
                 </button>
-                <button class="btn-icon" id="reset-btn" title="reset to defaults (⌘R)">
+                <button class="btn-icon" id="reset-btn" title="Reset to defaults (⌘R)" aria-label="Reset to defaults">
                     <i class="codicon codicon-debug-restart"></i>
                 </button>
             </div>
         </header>
 
-        <!-- ————— providers ————— -->
-        <section class="st-section">
-            <span class="section-marker">providers · byok</span>
+        <!-- ————— API Providers ————— -->
+        <section class="st-section" aria-labelledby="providers-heading">
+            <div class="st-section-head">
+                <h2 id="providers-heading" class="st-section-title">API providers</h2>
+                <p class="st-section-desc">Bring your own key. Add at least one to start generating.</p>
+            </div>
 
-            <!-- OpenAI -->
-            <div class="row">
-                <div class="row-head">
-                    <span class="row-key"><span class="prefix">api.</span>openai</span>
-                    <span class="row-hint">gpt-4o · gpt-4 · gpt-3.5 · prefix <code>sk-</code></span>
+            <div class="st-card">
+                <div class="st-provider">
+                    <div class="st-provider-head">
+                        <div class="st-provider-id">
+                            <span class="st-provider-name">OpenAI</span>
+                            <span id="status-openai" class="st-status">Not connected</span>
+                        </div>
+                        <span class="st-provider-hint">GPT-4o · GPT-4 · starts with <code>sk-</code></span>
+                    </div>
+                    <div class="st-provider-control">
+                        <input type="password" class="input" id="key-openai" placeholder="sk-…" autocomplete="off" spellcheck="false">
+                        <button class="btn btn-sm" id="test-openai">Test</button>
+                    </div>
                 </div>
-                <div class="row-control">
-                    <input type="password" class="input" id="key-openai" placeholder="sk-…" autocomplete="off" spellcheck="false">
-                    <button class="btn btn-sm" id="test-openai">test</button>
+
+                <div class="st-provider">
+                    <div class="st-provider-head">
+                        <div class="st-provider-id">
+                            <span class="st-provider-name">Anthropic</span>
+                            <span id="status-anthropic" class="st-status">Not connected</span>
+                        </div>
+                        <span class="st-provider-hint">Claude Opus · Sonnet · Haiku · starts with <code>sk-ant-</code></span>
+                    </div>
+                    <div class="st-provider-control">
+                        <input type="password" class="input" id="key-anthropic" placeholder="sk-ant-…" autocomplete="off" spellcheck="false">
+                        <button class="btn btn-sm" id="test-anthropic">Test</button>
+                    </div>
                 </div>
-                <div class="row-foot">
-                    <span id="status-openai" class="status">unset</span>
-                    <span class="dim">stored in vscode.secrets</span>
+
+                <div class="st-provider">
+                    <div class="st-provider-head">
+                        <div class="st-provider-id">
+                            <span class="st-provider-name">Google</span>
+                            <span id="status-google" class="st-status">Not connected</span>
+                        </div>
+                        <span class="st-provider-hint">Gemini Pro · starts with <code>AIza</code></span>
+                    </div>
+                    <div class="st-provider-control">
+                        <input type="password" class="input" id="key-google" placeholder="AIza…" autocomplete="off" spellcheck="false">
+                        <button class="btn btn-sm" id="test-google">Test</button>
+                    </div>
+                </div>
+
+                <div class="st-provider">
+                    <div class="st-provider-head">
+                        <div class="st-provider-id">
+                            <span class="st-provider-name">FlowCraft</span>
+                            <span id="status-flowcraft" class="st-status">Not connected</span>
+                        </div>
+                        <span class="st-provider-hint">FlowCraft hosted · starts with <code>fc_</code></span>
+                    </div>
+                    <div class="st-provider-control">
+                        <input type="password" class="input" id="key-flowcraft" placeholder="fc_…" autocomplete="off" spellcheck="false">
+                        <button class="btn btn-sm" id="test-flowcraft">Test</button>
+                    </div>
                 </div>
             </div>
 
-            <!-- Anthropic -->
-            <div class="row">
-                <div class="row-head">
-                    <span class="row-key"><span class="prefix">api.</span>anthropic</span>
-                    <span class="row-hint">claude 3 opus · sonnet · haiku · prefix <code>sk-ant-</code></span>
-                </div>
-                <div class="row-control">
-                    <input type="password" class="input" id="key-anthropic" placeholder="sk-ant-…" autocomplete="off" spellcheck="false">
-                    <button class="btn btn-sm" id="test-anthropic">test</button>
-                </div>
-                <div class="row-foot">
-                    <span id="status-anthropic" class="status">unset</span>
-                    <span class="dim">stored in vscode.secrets</span>
-                </div>
+            <p class="st-footnote"><i class="codicon codicon-shield"></i> Keys are stored securely in VS Code's secret storage — never synced or shared.</p>
+        </section>
+
+        <!-- ————— Defaults ————— -->
+        <section class="st-section" aria-labelledby="defaults-heading">
+            <div class="st-section-head">
+                <h2 id="defaults-heading" class="st-section-title">Defaults</h2>
+                <p class="st-section-desc">Pre-fills used when creating a new diagram.</p>
             </div>
 
-            <!-- Google -->
-            <div class="row">
-                <div class="row-head">
-                    <span class="row-key"><span class="prefix">api.</span>google</span>
-                    <span class="row-hint">gemini pro · prefix <code>AIza</code></span>
+            <div class="st-card">
+                <div class="st-field">
+                    <label class="st-field-label" for="default-provider">
+                        <span class="st-field-name">Active provider</span>
+                        <span class="st-field-hint">Which provider handles your requests</span>
+                    </label>
+                    <select class="input" id="default-provider">
+                        <option value="openai">OpenAI</option>
+                        <option value="anthropic">Anthropic</option>
+                        <option value="google">Google</option>
+                        <option value="flowcraft">FlowCraft</option>
+                    </select>
                 </div>
-                <div class="row-control">
-                    <input type="password" class="input" id="key-google" placeholder="AIza…" autocomplete="off" spellcheck="false">
-                    <button class="btn btn-sm" id="test-google">test</button>
-                </div>
-                <div class="row-foot">
-                    <span id="status-google" class="status">unset</span>
-                    <span class="dim">stored in vscode.secrets</span>
-                </div>
-            </div>
 
-            <!-- FlowCraft -->
-            <div class="row">
-                <div class="row-head">
-                    <span class="row-key"><span class="prefix">api.</span>flowcraft</span>
-                    <span class="row-hint">native cloud · prefix <code>fc_</code></span>
+                <div class="st-field">
+                    <label class="st-field-label" for="default-type">
+                        <span class="st-field-name">Diagram type</span>
+                        <span class="st-field-hint">Default style for new diagrams</span>
+                    </label>
+                    <select class="input" id="default-type">
+                        <option value="flowchart">Flowchart</option>
+                        <option value="sequence">Sequence</option>
+                        <option value="class">Class</option>
+                        <option value="state">State</option>
+                        <option value="er">Entity-Relationship</option>
+                        <option value="gantt">Gantt</option>
+                        <option value="pie">Pie chart</option>
+                    </select>
                 </div>
-                <div class="row-control">
-                    <input type="password" class="input" id="key-flowcraft" placeholder="fc_…" autocomplete="off" spellcheck="false">
-                    <button class="btn btn-sm" id="test-flowcraft">test</button>
+
+                <div class="st-field">
+                    <label class="st-field-label" for="default-palette">
+                        <span class="st-field-name">Color palette</span>
+                        <span class="st-field-hint">How new diagrams are colored</span>
+                    </label>
+                    <select class="input" id="default-palette">
+                        <option value="brand colors">Brand</option>
+                        <option value="monochromatic">Monochromatic</option>
+                        <option value="complementary">Complementary</option>
+                        <option value="analogous">Analogous</option>
+                    </select>
                 </div>
-                <div class="row-foot">
-                    <span id="status-flowcraft" class="status">unset</span>
-                    <span class="dim">stored in vscode.secrets</span>
+
+                <div class="st-field">
+                    <label class="st-field-label" for="default-complexity">
+                        <span class="st-field-name">Detail level</span>
+                        <span class="st-field-hint">How much the model elaborates</span>
+                    </label>
+                    <select class="input" id="default-complexity">
+                        <option value="simple">Simple</option>
+                        <option value="medium">Medium</option>
+                        <option value="complex">Detailed</option>
+                    </select>
                 </div>
             </div>
         </section>
 
-        <!-- ————— preferences ————— -->
-        <section class="st-section">
-            <span class="section-marker">defaults</span>
-
-            <div class="row row-inline">
-                <span class="row-key"><span class="prefix">default.</span>provider</span>
-                <select class="input input-inline" id="default-provider">
-                    <option value="openai">openai</option>
-                    <option value="anthropic">anthropic</option>
-                    <option value="google">google</option>
-                    <option value="flowcraft">flowcraft</option>
-                </select>
+        <!-- ————— Models per provider ————— -->
+        <section class="st-section" aria-labelledby="models-heading">
+            <div class="st-section-head">
+                <h2 id="models-heading" class="st-section-title">Model overrides</h2>
+                <p class="st-section-desc">Pick a specific model for each provider. Leave on <em>Default</em> to let FlowCraft choose.</p>
             </div>
 
-            <div class="row row-inline">
-                <span class="row-key"><span class="prefix">default.</span>diagram</span>
-                <select class="input input-inline" id="default-type">
-                    <option value="flowchart">flowchart</option>
-                    <option value="sequence">sequence</option>
-                    <option value="class">class</option>
-                    <option value="state">state</option>
-                    <option value="er">er</option>
-                    <option value="gantt">gantt</option>
-                    <option value="pie">pie</option>
-                </select>
-            </div>
+            <div class="st-card">
+                <div class="st-field">
+                    <label class="st-field-label" for="model-openai">
+                        <span class="st-field-name">OpenAI</span>
+                    </label>
+                    <select class="input" id="model-openai" data-provider="openai"></select>
+                </div>
 
-            <div class="row row-inline">
-                <span class="row-key"><span class="prefix">default.</span>palette</span>
-                <select class="input input-inline" id="default-palette">
-                    <option value="brand colors">brand</option>
-                    <option value="monochromatic">monochromatic</option>
-                    <option value="complementary">complementary</option>
-                    <option value="analogous">analogous</option>
-                </select>
-            </div>
+                <div class="st-field">
+                    <label class="st-field-label" for="model-anthropic">
+                        <span class="st-field-name">Anthropic</span>
+                    </label>
+                    <select class="input" id="model-anthropic" data-provider="anthropic"></select>
+                </div>
 
-            <div class="row row-inline">
-                <span class="row-key"><span class="prefix">default.</span>complexity</span>
-                <select class="input input-inline" id="default-complexity">
-                    <option value="simple">simple</option>
-                    <option value="medium">medium</option>
-                    <option value="complex">complex</option>
-                </select>
+                <div class="st-field">
+                    <label class="st-field-label" for="model-google">
+                        <span class="st-field-name">Google</span>
+                    </label>
+                    <select class="input" id="model-google" data-provider="google"></select>
+                </div>
+
+                <div class="st-field">
+                    <label class="st-field-label" for="model-flowcraft">
+                        <span class="st-field-name">FlowCraft</span>
+                    </label>
+                    <select class="input" id="model-flowcraft" data-provider="flowcraft"></select>
+                </div>
             </div>
         </section>
 
     </main>
 
     <footer class="st-foot">
-        <span class="st-foot-cell"><span class="dim">⌘S</span> save</span>
-        <span class="st-foot-cell"><span class="dim">⌘R</span> reset</span>
-        <span class="st-foot-cell" id="foot-status">idle</span>
-        <button class="btn btn-primary" id="save-btn">save changes</button>
+        <span class="st-foot-status" id="foot-status">No unsaved changes</span>
+        <div class="st-foot-actions">
+            <span class="st-foot-hint"><kbd>⌘S</kbd> to save</span>
+            <button class="btn btn-primary" id="save-btn">Save changes</button>
+        </div>
     </footer>
 
     <script type="module" nonce="{{nonce}}" src="{{settingsJs}}"></script>

--- a/media/webview/settings/settings.css
+++ b/media/webview/settings/settings.css
@@ -1,114 +1,299 @@
-/* Settings — config-file layout */
+/* Settings — refined panel, Apple/Airbnb-inspired */
+
+:root {
+  --st-radius: 12px;
+  --st-radius-sm: 8px;
+  --st-font-ui: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", system-ui, sans-serif);
+  --st-fs-title: 22px;
+  --st-fs-section: 15px;
+  --st-fs-field: 13px;
+  --st-fs-body: 12.5px;
+  --st-fs-label: 11px;
+  --st-pad: 20px;
+}
 
 body { padding: 0; overflow-x: hidden; }
 
 .st {
-  padding: var(--fc-sp-5);
-  padding-bottom: 72px; /* room for sticky footer */
+  padding: 24px var(--st-pad) 96px;
   display: flex;
   flex-direction: column;
-  gap: var(--fc-sp-7);
-  max-width: 820px;
+  gap: 32px;
+  max-width: 720px;
   margin: 0 auto;
+  font-family: var(--st-font-ui);
+  font-size: var(--st-fs-body);
+  line-height: 1.5;
+  letter-spacing: 0;
 }
+.st * { font-family: var(--st-font-ui); }
+.st code, .st kbd { font-family: var(--fc-font-mono); }
 
-/* Head ——————————————————————————— */
+/* Header ——————————————————————————— */
 .st-head {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: var(--fc-sp-4);
-  padding-bottom: var(--fc-sp-4);
-  border-bottom: 1px dashed var(--fc-border);
+  gap: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--fc-border);
 }
-.st-path {
-  font-family: var(--fc-font-mono);
-  font-size: var(--fc-fs-md);
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
+.st-head-text { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.st-title {
+  font-size: var(--st-fs-title);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--fc-fg);
+  text-transform: none;
+  line-height: 1.2;
 }
-.st-path .dim { color: var(--fc-fg-dim); }
-.st-actions { display: inline-flex; gap: var(--fc-sp-2); }
+.st-subtitle {
+  font-size: var(--st-fs-body);
+  color: var(--fc-fg-muted);
+  line-height: 1.4;
+  max-width: 440px;
+}
+.st-head-actions { display: inline-flex; gap: 4px; flex-shrink: 0; }
+.st-head-actions .btn-icon { width: 30px; height: 30px; border-radius: var(--st-radius-sm); }
 
-/* Sections ——————————————————————————— */
+/* Section ——————————————————————————— */
 .st-section {
   display: flex;
   flex-direction: column;
+  gap: 14px;
 }
+.st-section-head { display: flex; flex-direction: column; gap: 4px; padding: 0 2px; }
+.st-section-title {
+  font-size: var(--st-fs-section);
+  font-weight: 600;
+  color: var(--fc-fg);
+  letter-spacing: -0.01em;
+  text-transform: none;
+}
+.st-section-desc {
+  font-size: var(--st-fs-body);
+  color: var(--fc-fg-muted);
+  line-height: 1.4;
+}
+.st-section-desc em { font-style: normal; color: var(--fc-fg); font-weight: 500; }
 
-/* Row overrides ——————————————————————————— */
-.row code {
-  padding: 0 3px;
+/* Card ——————————————————————————— */
+.st-card {
   background: var(--fc-surface);
   border: 1px solid var(--fc-border);
-  border-radius: 2px;
-  color: var(--fc-fg);
-  font-size: 10px;
+  border-radius: var(--st-radius);
+  overflow: hidden;
 }
 
-.row-inline {
-  display: grid;
-  grid-template-columns: minmax(200px, 1fr) auto;
-  align-items: center;
-  padding: var(--fc-sp-4) 0;
-  gap: var(--fc-sp-5);
+/* Provider rows (in card) ——————————————————————————— */
+.st-provider {
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-bottom: 1px solid var(--fc-border);
 }
-.row-inline .row-key {
-  display: inline-flex;
+.st-provider:last-child { border-bottom: none; }
+
+.st-provider-head {
+  display: flex;
   align-items: baseline;
-  gap: 4px;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 6px 12px;
 }
-.input-inline {
-  width: auto;
-  min-width: 160px;
-  padding: var(--fc-sp-2) var(--fc-sp-4);
-  padding-right: 28px;
+.st-provider-id {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
 }
-
-/* Status text ——————————————————————————— */
-.status {
-  font-family: var(--fc-font-mono);
-  font-size: var(--fc-fs-sm);
+.st-provider-name {
+  font-size: var(--st-fs-field);
+  font-weight: 600;
+  color: var(--fc-fg);
+}
+.st-provider-hint {
+  font-size: var(--st-fs-label);
   color: var(--fc-fg-muted);
+  line-height: 1.4;
 }
-.status.ok  { color: var(--fc-ok); }
-.status.err { color: var(--fc-err); }
-.status.warn { color: var(--fc-warn); }
-.status::before {
-  content: "● ";
-  color: currentColor;
-  opacity: 0.75;
+.st-provider-hint code {
+  padding: 1px 5px;
+  background: var(--fc-bg-alt);
+  border: 1px solid var(--fc-border);
+  border-radius: 4px;
+  color: var(--fc-fg);
+  font-size: 10.5px;
 }
 
-/* Footer action bar (sticky) ——————————————————————————— */
+.st-provider-control {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.st-provider-control .input {
+  flex: 1;
+  padding: 8px 10px;
+  border-radius: var(--st-radius-sm);
+  font-family: var(--fc-font-mono);
+  font-size: 12px;
+}
+.st-provider-control .btn {
+  border-radius: var(--st-radius-sm);
+  padding: 7px 14px;
+  font-weight: 500;
+  font-family: var(--st-font-ui);
+}
+
+/* Status pill ——————————————————————————— */
+.st-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: var(--st-fs-label);
+  font-weight: 500;
+  color: var(--fc-fg-muted);
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--fc-bg-alt);
+  border: 1px solid var(--fc-border);
+}
+.st-status::before {
+  content: "";
+  display: inline-block;
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--fc-fg-dim);
+}
+.st-status.ok    { color: var(--fc-ok);   border-color: color-mix(in srgb, var(--fc-ok) 35%, transparent); background: color-mix(in srgb, var(--fc-ok) 10%, transparent); }
+.st-status.ok::before { background: var(--fc-ok); }
+.st-status.err   { color: var(--fc-err);  border-color: color-mix(in srgb, var(--fc-err) 35%, transparent); background: color-mix(in srgb, var(--fc-err) 10%, transparent); }
+.st-status.err::before { background: var(--fc-err); }
+.st-status.warn  { color: var(--fc-warn); border-color: color-mix(in srgb, var(--fc-warn) 35%, transparent); background: color-mix(in srgb, var(--fc-warn) 10%, transparent); }
+.st-status.warn::before { background: var(--fc-warn); }
+
+/* Field (preferences, models) ——————————————————————————— */
+.st-field {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(180px, 220px);
+  align-items: center;
+  gap: 16px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--fc-border);
+}
+.st-field:last-child { border-bottom: none; }
+
+.st-field-label {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  cursor: pointer;
+}
+.st-field-name {
+  font-size: var(--st-fs-field);
+  font-weight: 500;
+  color: var(--fc-fg);
+}
+.st-field-hint {
+  font-size: var(--st-fs-body);
+  color: var(--fc-fg-muted);
+  line-height: 1.35;
+}
+
+.st-field .input {
+  padding: 7px 28px 7px 10px;
+  border-radius: var(--st-radius-sm);
+  font-family: var(--st-font-ui);
+  font-size: var(--st-fs-field);
+}
+
+@media (max-width: 520px) {
+  .st-field {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+  .st-field .input { width: 100%; }
+}
+
+/* Footnote ——————————————————————————— */
+.st-footnote {
+  font-size: var(--st-fs-label);
+  color: var(--fc-fg-muted);
+  padding: 0 4px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  line-height: 1.4;
+}
+.st-footnote i { font-size: 13px; color: var(--fc-fg-dim); }
+
+/* Sticky footer ——————————————————————————— */
 .st-foot {
   position: fixed;
   left: 0; right: 0; bottom: 0;
   display: flex;
   align-items: center;
-  gap: var(--fc-sp-5);
-  padding: var(--fc-sp-3) var(--fc-sp-5);
-  background: color-mix(in srgb, var(--fc-bg) 88%, transparent);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px var(--st-pad);
+  background: color-mix(in srgb, var(--fc-bg) 92%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
   border-top: 1px solid var(--fc-border);
-  font-family: var(--fc-font-mono);
-  font-size: var(--fc-fs-sm);
+  font-family: var(--st-font-ui);
+  font-size: var(--st-fs-body);
   color: var(--fc-fg-muted);
   z-index: 10;
 }
-.st-foot-cell { display: inline-flex; align-items: center; gap: 6px; }
-.st-foot .dim { color: var(--fc-fg-dim); }
-.st-foot #save-btn { margin-left: auto; }
+.st-foot-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.st-foot-status.ok { color: var(--fc-ok); }
+.st-foot-status.err { color: var(--fc-err); }
 
-/* Entrance */
-.st-head, .st-section { animation: st-in 220ms ease-out both; }
-.st-section:nth-of-type(2) { animation-delay: 40ms; }
-.st-section:nth-of-type(3) { animation-delay: 80ms; }
+.st-foot-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+.st-foot-hint {
+  font-size: var(--st-fs-label);
+  color: var(--fc-fg-dim);
+}
+.st-foot-hint kbd {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 4px;
+  border: 1px solid var(--fc-border);
+  background: var(--fc-bg-alt);
+  color: var(--fc-fg-muted);
+}
+.st-foot #save-btn {
+  border-radius: var(--st-radius-sm);
+  padding: 8px 18px;
+  font-weight: 600;
+  font-family: var(--st-font-ui);
+  font-size: var(--st-fs-field);
+}
+
+/* Entrance ——————————————————————————— */
+.st-head     { animation: st-in 260ms ease-out both; }
+.st-section  { animation: st-in 260ms ease-out both; }
+.st-section:nth-of-type(1) { animation-delay: 60ms; }
+.st-section:nth-of-type(2) { animation-delay: 110ms; }
+.st-section:nth-of-type(3) { animation-delay: 160ms; }
 
 @keyframes st-in {
-  from { opacity: 0; transform: translateY(3px); }
+  from { opacity: 0; transform: translateY(4px); }
   to   { opacity: 1; transform: none; }
 }
 

--- a/media/webview/settings/settings.js
+++ b/media/webview/settings/settings.js
@@ -3,6 +3,22 @@ import { getById, queryAll } from '../shared/utils/dom.js';
 
 const PROVIDERS = ['openai', 'anthropic', 'google', 'flowcraft'];
 
+// Curated model lists per provider — mirrors PROVIDER_INFO in src/types/api.ts.
+// Keep in sync when the TypeScript list changes.
+const MODELS_BY_PROVIDER = {
+  openai: ['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'o1-mini', 'o3-mini'],
+  anthropic: [
+    'claude-opus-4-20250514',
+    'claude-sonnet-4-20250514',
+    'claude-haiku-4-20250514',
+    'claude-3-7-sonnet-20250219',
+    'claude-3-5-sonnet-20241022',
+    'claude-3-5-haiku-20241022'
+  ],
+  google: ['gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-1.5-pro', 'gemini-1.5-flash'],
+  flowcraft: ['flowcraft-default']
+};
+
 let currentSettings = {};
 let currentProviders = {};
 let keysRevealed = false;
@@ -18,22 +34,22 @@ document.addEventListener('DOMContentLoaded', () => {
       render();
     },
     connectionResult: ({ provider, success, message }) => {
-      setStatus(provider, success ? 'ok' : 'err', success ? 'verified' : (message || 'failed'));
+      setStatus(provider, success ? 'ok' : 'err', success ? 'Connected' : (message || 'Failed to connect'));
       const btn = getById(`test-${provider}`);
-      if (btn) { btn.disabled = false; btn.textContent = 'test'; }
+      if (btn) { btn.disabled = false; btn.textContent = 'Test'; }
     },
     saveComplete: ({ success }) => {
       const btn = getById('save-btn');
       const foot = getById('foot-status');
       if (btn) {
-        btn.textContent = success ? 'saved' : 'save failed';
+        btn.textContent = success ? 'Saved' : 'Save failed';
         btn.disabled = false;
-        setTimeout(() => { btn.textContent = 'save changes'; }, 1400);
+        setTimeout(() => { btn.textContent = 'Save changes'; }, 1400);
       }
       if (foot) {
-        foot.textContent = success ? 'changes written' : 'write failed';
-        foot.className = 'st-foot-cell ' + (success ? 'ok' : 'err');
-        setTimeout(() => { foot.textContent = 'idle'; foot.className = 'st-foot-cell'; }, 1800);
+        foot.textContent = success ? 'Changes saved' : 'Could not save changes';
+        foot.className = 'st-foot-status ' + (success ? 'ok' : 'err');
+        setTimeout(() => { foot.textContent = 'No unsaved changes'; foot.className = 'st-foot-status'; }, 2000);
       }
     }
   });
@@ -48,12 +64,12 @@ function wire() {
       const input = getById(`key-${provider}`);
       const apiKey = input && input.value;
       if (!apiKey) {
-        setStatus(provider, 'err', 'enter a key first');
+        setStatus(provider, 'err', 'Enter a key first');
         return;
       }
       btn.disabled = true;
-      btn.textContent = '…';
-      setStatus(provider, 'warn', 'checking…');
+      btn.textContent = 'Testing…';
+      setStatus(provider, 'warn', 'Checking…');
       postMessage('testConnection', { provider, apiKey });
     });
   });
@@ -63,7 +79,7 @@ function wire() {
 
   // Reset
   getById('reset-btn')?.addEventListener('click', () => {
-    if (confirm('reset all settings to defaults?')) postMessage('resetSettings');
+    if (confirm('Reset all settings to their defaults? Your API keys will be kept.')) postMessage('resetSettings');
   });
 
   // Reveal / hide passwords
@@ -79,13 +95,22 @@ function wire() {
   document.addEventListener('keydown', (e) => {
     const mod = e.metaKey || e.ctrlKey;
     if (mod && e.key === 's') { e.preventDefault(); save(); }
-    if (mod && e.key === 'r') { e.preventDefault(); if (confirm('reset all settings to defaults?')) postMessage('resetSettings'); }
+    if (mod && e.key === 'r') { e.preventDefault(); if (confirm('Reset all settings to their defaults? Your API keys will be kept.')) postMessage('resetSettings'); }
   });
 }
 
 function save() {
   const btn = getById('save-btn');
-  if (btn) { btn.disabled = true; btn.textContent = 'saving…'; }
+  if (btn) { btn.disabled = true; btn.textContent = 'Saving…'; }
+
+  const providerModels = { ...(currentSettings.providerModels || {}) };
+  PROVIDERS.forEach(p => {
+    const sel = getById(`model-${p}`);
+    if (!sel) return;
+    const v = sel.value;
+    if (!v) delete providerModels[p];
+    else providerModels[p] = v;
+  });
 
   const newSettings = {
     ...currentSettings,
@@ -93,6 +118,7 @@ function save() {
     defaultDiagramType:  getById('default-type').value,
     defaultColorPalette: getById('default-palette').value,
     defaultComplexity:   getById('default-complexity').value,
+    providerModels
   };
 
   const apiKeys = {};
@@ -108,20 +134,44 @@ function render() {
   if (!currentSettings) return;
 
   Object.entries(currentProviders || {}).forEach(([provider, configured]) => {
-    if (configured) setStatus(provider, 'ok', 'configured');
-    else            setStatus(provider, '',   'unset');
+    if (configured) setStatus(provider, 'ok', 'Connected');
+    else            setStatus(provider, '',   'Not connected');
   });
 
   setSelect('default-provider',   currentSettings.defaultProvider);
   setSelect('default-type',       currentSettings.defaultDiagramType);
   setSelect('default-palette',    currentSettings.defaultColorPalette);
   setSelect('default-complexity', currentSettings.defaultComplexity);
+
+  renderModelSelects();
+}
+
+function renderModelSelects() {
+  const chosen = currentSettings.providerModels || {};
+  PROVIDERS.forEach(p => {
+    const sel = getById(`model-${p}`);
+    if (!sel) return;
+    const models = MODELS_BY_PROVIDER[p] || [];
+    // Build: a "default" option (sends no override), then curated models.
+    sel.innerHTML = '';
+    const defOpt = document.createElement('option');
+    defOpt.value = '';
+    defOpt.textContent = 'Default (recommended)';
+    sel.appendChild(defOpt);
+    models.forEach(m => {
+      const o = document.createElement('option');
+      o.value = m;
+      o.textContent = m;
+      sel.appendChild(o);
+    });
+    sel.value = chosen[p] || '';
+  });
 }
 
 function setStatus(provider, state, text) {
   const el = getById(`status-${provider}`);
   if (!el) return;
-  el.className = 'status' + (state ? ' ' + state : '');
+  el.className = 'st-status' + (state ? ' ' + state : '');
   el.textContent = text;
 }
 

--- a/media/webview/welcome/index.html
+++ b/media/webview/welcome/index.html
@@ -15,98 +15,121 @@
     <main class="wc">
 
         <header class="wc-head">
-            <div class="wc-prompt">
-                <span class="wc-prompt-user">flowcraft</span><span class="wc-prompt-sep">@</span><span class="wc-prompt-host">vscode</span>
-                <span class="wc-prompt-path">~/diagrams</span>
-                <span class="wc-prompt-caret">$</span>
+            <div class="wc-brand">
+                <div class="wc-mark" aria-hidden="true">
+                    <span class="wc-mark-glyph">◈</span>
+                </div>
+                <div class="wc-brand-text">
+                    <h1 class="wc-title">FlowCraft</h1>
+                    <p class="wc-subtitle">Turn code and ideas into clear diagrams.</p>
+                </div>
             </div>
-            <div class="wc-version muted">v2.1.0</div>
         </header>
 
-        <section class="wc-status" aria-label="subscription status">
-            <div class="wc-status-row">
-                <span class="wc-status-label">plan</span>
-                <span id="subscription-badge" class="tag"><span class="dot"></span>free</span>
+        <section class="wc-card wc-plan" aria-label="Subscription and usage">
+            <div class="wc-plan-head">
+                <div class="wc-plan-heading">
+                    <span class="wc-eyebrow">Your plan</span>
+                    <span id="subscription-badge" class="tag"><span class="dot"></span>Free</span>
+                </div>
+                <a href="#" id="link-upgrade" class="wc-upgrade hidden">Upgrade</a>
             </div>
-            <div class="progress" id="usage-progress" aria-hidden="false">
+            <div class="progress" id="usage-progress">
                 <div class="fill" id="usage-fill" style="width: 0%"></div>
             </div>
-            <div class="wc-status-row wc-status-foot">
-                <span id="usage-text" class="mono muted">—</span>
-                <span id="usage-limit" class="mono muted"></span>
+            <div class="wc-plan-foot">
+                <span id="usage-text" class="wc-usage-text">Loading usage…</span>
+                <span id="usage-limit" class="wc-usage-limit"></span>
             </div>
         </section>
 
-        <span class="section-marker">actions</span>
+        <section aria-labelledby="wc-actions-heading">
+            <h2 id="wc-actions-heading" class="wc-section-title">Create</h2>
 
-        <nav class="wc-actions" aria-label="commands">
-            <button class="tile" id="action-diagram" data-key="1">
-                <span class="tile-num">1</span>
-                <span class="tile-body">
-                    <span class="tile-title">generate diagram</span>
-                    <span class="tile-desc">flowchart · sequence · class · er · …</span>
-                </span>
-                <span class="kbd">⌘⇧D</span>
-            </button>
+            <nav class="wc-actions" aria-label="Create actions">
+                <button class="wc-tile" id="action-diagram" data-key="1">
+                    <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-symbol-structure"></i></span>
+                    <span class="wc-tile-body">
+                        <span class="wc-tile-title">Create a diagram</span>
+                        <span class="wc-tile-desc">Flowchart, sequence, class, ER and more</span>
+                    </span>
+                    <span class="kbd">⌘⇧D</span>
+                </button>
 
-            <button class="tile" id="action-selection" data-key="2">
-                <span class="tile-num">2</span>
-                <span class="tile-body">
-                    <span class="tile-title">from selection</span>
-                    <span class="tile-desc">use the highlighted text in the editor</span>
-                </span>
-                <span class="kbd">⌘⇧G</span>
-            </button>
+                <button class="wc-tile" id="action-selection" data-key="2">
+                    <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-selection"></i></span>
+                    <span class="wc-tile-body">
+                        <span class="wc-tile-title">From editor selection</span>
+                        <span class="wc-tile-desc">Generate a diagram from highlighted code</span>
+                    </span>
+                    <span class="kbd">⌘⇧G</span>
+                </button>
 
-            <button class="tile" id="action-infographic" data-key="3">
-                <span class="tile-num">3</span>
-                <span class="tile-body">
-                    <span class="tile-title">infographic <span class="tag">soon</span></span>
-                    <span class="tile-desc">visual data summary</span>
-                </span>
-                <span class="kbd">—</span>
-            </button>
+                <button class="wc-tile" id="action-infographic" data-key="3" disabled>
+                    <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-graph"></i></span>
+                    <span class="wc-tile-body">
+                        <span class="wc-tile-title">Infographic <span class="tag tag-soon">Coming soon</span></span>
+                        <span class="wc-tile-desc">Visual summaries from data or notes</span>
+                    </span>
+                </button>
 
-            <button class="tile" id="action-image" data-key="4">
-                <span class="tile-num">4</span>
-                <span class="tile-body">
-                    <span class="tile-title">illustration <span class="tag">soon</span></span>
-                    <span class="tile-desc">ai-rendered image</span>
-                </span>
-                <span class="kbd">—</span>
-            </button>
+                <button class="wc-tile" id="action-image" data-key="4" disabled>
+                    <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-symbol-color"></i></span>
+                    <span class="wc-tile-body">
+                        <span class="wc-tile-title">Illustration <span class="tag tag-soon">Coming soon</span></span>
+                        <span class="wc-tile-desc">AI-rendered images for your docs</span>
+                    </span>
+                </button>
+            </nav>
+        </section>
 
-            <button class="tile" id="action-history" data-key="5">
-                <span class="tile-num">5</span>
-                <span class="tile-body">
-                    <span class="tile-title">history</span>
-                    <span class="tile-desc">previously generated diagrams</span>
-                </span>
-                <span class="kbd">⌘H</span>
-            </button>
-        </nav>
+        <section aria-labelledby="wc-library-heading">
+            <h2 id="wc-library-heading" class="wc-section-title">Library</h2>
+            <nav class="wc-actions" aria-label="Library">
+                <button class="wc-tile" id="action-history" data-key="5">
+                    <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-history"></i></span>
+                    <span class="wc-tile-body">
+                        <span class="wc-tile-title">Recent diagrams</span>
+                        <span class="wc-tile-desc">Reopen something you made before</span>
+                    </span>
+                    <span class="kbd">⌘H</span>
+                </button>
+            </nav>
+        </section>
 
-        <span class="section-marker">shortcuts</span>
-
-        <ul class="wc-links">
-            <li><a href="#" id="link-settings" class="wc-link">
-                <span class="wc-link-caret">›</span> settings &amp; api keys
-                <span class="kbd">⌘,</span>
-            </a></li>
-            <li><a href="https://flowcraft.app/docs" class="wc-link">
-                <span class="wc-link-caret">›</span> docs
-                <span class="muted">flowcraft.app/docs</span>
-            </a></li>
-            <li><a href="https://github.com/flowcraft/vscode/issues" class="wc-link">
-                <span class="wc-link-caret">›</span> report issue
-                <span class="muted">github</span>
-            </a></li>
-        </ul>
+        <section aria-labelledby="wc-more-heading">
+            <h2 id="wc-more-heading" class="wc-section-title">More</h2>
+            <ul class="wc-links">
+                <li>
+                    <a href="#" id="link-settings" class="wc-link">
+                        <span class="wc-link-icon" aria-hidden="true"><i class="codicon codicon-settings-gear"></i></span>
+                        <span class="wc-link-label">Settings &amp; API keys</span>
+                        <span class="kbd">⌘,</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="https://flowcraft.app/docs" class="wc-link">
+                        <span class="wc-link-icon" aria-hidden="true"><i class="codicon codicon-book"></i></span>
+                        <span class="wc-link-label">Documentation</span>
+                        <span class="wc-link-meta"><i class="codicon codicon-link-external"></i></span>
+                    </a>
+                </li>
+                <li>
+                    <a href="https://github.com/flowcraft/vscode/issues" class="wc-link">
+                        <span class="wc-link-icon" aria-hidden="true"><i class="codicon codicon-comment-discussion"></i></span>
+                        <span class="wc-link-label">Send feedback</span>
+                        <span class="wc-link-meta"><i class="codicon codicon-link-external"></i></span>
+                    </a>
+                </li>
+            </ul>
+        </section>
 
         <footer class="wc-foot">
-            <span class="wc-foot-cell"><span class="dim">STATUS</span> <span id="foot-status" class="ok">ready</span></span>
-            <span class="wc-foot-cell"><span class="dim">MODE</span> <span id="foot-mode">byok</span></span>
-            <span class="wc-foot-cell"><span class="dim">TIP</span> press <kbd>1</kbd>–<kbd>5</kbd> or <kbd>⌘⇧P</kbd> → flowcraft</span>
+            <p class="wc-tip">
+                <span class="wc-tip-label">Tip</span>
+                Press <kbd>1</kbd>–<kbd>5</kbd> to jump to any action, or open the Command Palette with <kbd>⌘⇧P</kbd>.
+            </p>
+            <p class="wc-version">FlowCraft v2.1.0</p>
         </footer>
     </main>
 

--- a/media/webview/welcome/welcome.css
+++ b/media/webview/welcome/welcome.css
@@ -1,139 +1,320 @@
-/* Welcome — terminal-pane layout */
+/* Welcome — refined sidebar, Apple/Airbnb-inspired */
+
+:root {
+  --wc-radius: 10px;
+  --wc-radius-sm: 8px;
+  --wc-font-ui: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", system-ui, sans-serif);
+  --wc-fs-title: 17px;
+  --wc-fs-tile: 13px;
+  --wc-fs-body: 12.5px;
+  --wc-fs-label: 11px;
+  --wc-pad: 16px;
+}
 
 body { padding: 0; overflow-x: hidden; }
 
 .wc {
   display: flex;
   flex-direction: column;
-  gap: var(--fc-sp-6);
-  padding: var(--fc-sp-5);
+  gap: 20px;
+  padding: 18px var(--wc-pad) 14px;
   min-height: 100vh;
+  font-family: var(--wc-font-ui);
+  font-size: var(--wc-fs-body);
+  line-height: 1.5;
+  letter-spacing: 0;
 }
 
-/* Prompt line ——————————————————————————— */
-.wc-head {
+.wc * { font-family: var(--wc-font-ui); }
+.wc .kbd, .wc kbd { font-family: var(--fc-font-mono); }
+
+/* Header ——————————————————————————— */
+.wc-head { padding-top: 4px; }
+.wc-brand {
   display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: var(--fc-sp-4);
-  padding-bottom: var(--fc-sp-4);
-  border-bottom: 1px dashed var(--fc-border);
+  align-items: center;
+  gap: 12px;
 }
-.wc-prompt {
-  font-family: var(--fc-font-mono);
-  font-size: var(--fc-fs-md);
-  color: var(--fc-fg);
-  letter-spacing: 0.01em;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.wc-prompt-user { color: var(--fc-accent); }
-.wc-prompt-sep  { color: var(--fc-fg-dim); }
-.wc-prompt-host { color: var(--fc-fg-muted); }
-.wc-prompt-path { color: var(--fc-fg-muted); margin-left: var(--fc-sp-3); }
-.wc-prompt-caret {
+.wc-mark {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--wc-radius-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--fc-accent) 14%, transparent);
   color: var(--fc-accent);
-  margin-left: var(--fc-sp-3);
-  animation: wc-blink 1.1s steps(1) infinite;
+  flex-shrink: 0;
 }
-@keyframes wc-blink { 50% { opacity: 0; } }
-
-.wc-version {
-  font-size: var(--fc-fs-sm);
-  font-family: var(--fc-font-mono);
+.wc-mark-glyph { font-size: 18px; line-height: 1; }
+.wc-brand-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.wc-title {
+  font-size: var(--wc-fs-title);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--fc-fg);
+  text-transform: none;
+  line-height: 1.2;
+}
+.wc-subtitle {
+  font-size: var(--wc-fs-body);
+  color: var(--fc-fg-muted);
+  line-height: 1.35;
 }
 
-/* Status block ——————————————————————————— */
-.wc-status {
-  display: flex;
-  flex-direction: column;
-  gap: var(--fc-sp-3);
-  padding: var(--fc-sp-4) var(--fc-sp-5);
+/* Plan card ——————————————————————————— */
+.wc-card {
   background: var(--fc-surface);
   border: 1px solid var(--fc-border);
-  border-radius: var(--fc-radius-1);
+  border-radius: var(--wc-radius);
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
-.wc-status-row {
+.wc-plan-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--fc-sp-4);
+  gap: 8px;
 }
-.wc-status-label {
-  font-family: var(--fc-font-mono);
-  font-size: var(--fc-fs-sm);
+.wc-plan-heading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.wc-eyebrow {
+  font-size: var(--wc-fs-label);
+  font-weight: 600;
+  color: var(--fc-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.wc .tag {
+  font-family: var(--wc-font-ui);
+  font-size: var(--wc-fs-label);
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: 0;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--fc-bg-alt);
+}
+.wc .tag .dot { width: 6px; height: 6px; }
+
+.wc-upgrade {
+  font-size: var(--wc-fs-body);
+  font-weight: 600;
+  color: var(--fc-accent);
+  border-bottom: none;
+}
+.wc-upgrade:hover { text-decoration: underline; border-bottom: none; }
+
+.wc-card .progress {
+  height: 6px;
+  border-radius: 999px;
+  border: none;
+  background: color-mix(in srgb, var(--fc-fg) 10%, transparent);
+}
+.wc-card .progress > .fill { border-radius: 999px; }
+
+.wc-plan-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: var(--wc-fs-body);
+}
+.wc-usage-text { color: var(--fc-fg); font-weight: 500; }
+.wc-usage-limit { color: var(--fc-fg-muted); }
+
+/* Sections ——————————————————————————— */
+.wc-section-title {
+  font-size: var(--wc-fs-label);
+  font-weight: 600;
   color: var(--fc-fg-muted);
   text-transform: uppercase;
   letter-spacing: 0.08em;
+  margin-bottom: 8px;
+  padding: 0 2px;
 }
-.wc-status-foot { font-size: var(--fc-fs-sm); }
 
 /* Actions ——————————————————————————— */
 .wc-actions {
   display: flex;
   flex-direction: column;
-  gap: var(--fc-sp-3);
+  gap: 6px;
 }
 
-/* Links list ——————————————————————————— */
+.wc-tile {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 12px 12px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--wc-radius-sm);
+  cursor: pointer;
+  color: var(--fc-fg);
+  text-align: left;
+  font-family: var(--wc-font-ui);
+  transition: background var(--fc-t-fast), border-color var(--fc-t-fast), transform var(--fc-t-fast);
+}
+.wc-tile:hover:not(:disabled) {
+  background: var(--fc-surface);
+  border-color: var(--fc-border);
+}
+.wc-tile:active:not(:disabled) { transform: scale(0.99); }
+.wc-tile:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+.wc-tile:focus-visible {
+  outline: 2px solid var(--fc-border-hi);
+  outline-offset: 1px;
+}
+
+.wc-tile-icon {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--fc-bg-alt);
+  color: var(--fc-fg);
+  border-radius: var(--wc-radius-sm);
+  flex-shrink: 0;
+}
+.wc-tile-icon i { font-size: 16px; }
+.wc-tile:hover:not(:disabled) .wc-tile-icon {
+  background: color-mix(in srgb, var(--fc-accent) 14%, transparent);
+  color: var(--fc-accent);
+}
+
+.wc-tile-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.wc-tile-title {
+  font-size: var(--wc-fs-tile);
+  font-weight: 600;
+  color: var(--fc-fg);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.wc-tile-desc {
+  font-size: var(--wc-fs-body);
+  color: var(--fc-fg-muted);
+  line-height: 1.35;
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.wc .kbd {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 5px;
+  border: 1px solid var(--fc-border);
+  background: var(--fc-bg-alt);
+  color: var(--fc-fg-muted);
+  font-weight: 500;
+}
+
+.tag-soon {
+  color: var(--fc-fg-muted);
+  background: var(--fc-bg-alt);
+}
+
+/* Links ——————————————————————————— */
 .wc-links {
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: var(--fc-sp-1);
+  gap: 2px;
 }
 .wc-link {
   display: flex;
   align-items: center;
-  gap: var(--fc-sp-3);
-  padding: var(--fc-sp-2) var(--fc-sp-3);
-  font-family: var(--fc-font-mono);
-  font-size: var(--fc-fs);
+  gap: 12px;
+  padding: 10px 12px;
+  font-size: var(--wc-fs-tile);
   color: var(--fc-fg);
+  border-radius: var(--wc-radius-sm);
   border: 1px solid transparent;
-  border-radius: var(--fc-radius-1);
+  border-bottom: 1px solid transparent;
 }
 .wc-link:hover {
   background: var(--fc-surface);
   border-color: var(--fc-border);
-  border-bottom-color: var(--fc-border); /* override anchor dashed underline */
+  border-bottom-color: var(--fc-border);
 }
-.wc-link-caret { color: var(--fc-fg-dim); }
-.wc-link .kbd, .wc-link .muted { margin-left: auto; }
+.wc-link-icon {
+  width: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fc-fg-muted);
+}
+.wc-link-icon i { font-size: 15px; }
+.wc-link-label { flex: 1; font-weight: 500; }
+.wc-link-meta { color: var(--fc-fg-dim); font-size: 11px; }
+.wc-link-meta i { font-size: 12px; }
+.wc-link .kbd { margin-left: auto; }
 
-/* Status line (terminal footer) ——————————————————— */
+/* Footer ——————————————————————————— */
 .wc-foot {
   margin-top: auto;
+  padding-top: 14px;
+  border-top: 1px solid var(--fc-border);
   display: flex;
-  flex-wrap: wrap;
-  gap: var(--fc-sp-5);
-  padding: var(--fc-sp-3) var(--fc-sp-4);
-  font-family: var(--fc-font-mono);
-  font-size: 10px;
-  color: var(--fc-fg-muted);
-  background: var(--fc-surface);
-  border: 1px solid var(--fc-border);
-  border-radius: var(--fc-radius-1);
-  letter-spacing: 0.04em;
+  flex-direction: column;
+  gap: 6px;
 }
-.wc-foot .dim { color: var(--fc-fg-dim); margin-right: 4px; }
-.wc-foot-cell { display: inline-flex; align-items: center; gap: 4px; }
-.wc-foot kbd { font-size: 9px; padding: 0 4px; }
+.wc-tip {
+  font-size: var(--wc-fs-body);
+  color: var(--fc-fg-muted);
+  line-height: 1.5;
+}
+.wc-tip-label {
+  font-weight: 600;
+  color: var(--fc-fg);
+  margin-right: 4px;
+}
+.wc-tip kbd {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 4px;
+  border: 1px solid var(--fc-border);
+  background: var(--fc-bg-alt);
+  color: var(--fc-fg-muted);
+  margin: 0 1px;
+}
+.wc-version {
+  font-size: var(--wc-fs-label);
+  color: var(--fc-fg-dim);
+  letter-spacing: 0.02em;
+}
 
-/* Entrance — one subtle, staggered reveal */
-.wc-head     { animation: wc-in 220ms ease-out both; }
-.wc-status   { animation: wc-in 220ms ease-out 40ms  both; }
-.wc-actions  { animation: wc-in 220ms ease-out 80ms  both; }
-.wc-links    { animation: wc-in 220ms ease-out 120ms both; }
-.wc-foot     { animation: wc-in 220ms ease-out 160ms both; }
+/* Entrance animation ——————————————————————————— */
+.wc-head     { animation: wc-in 260ms ease-out both; }
+.wc-card     { animation: wc-in 260ms ease-out 60ms  both; }
+.wc > section:nth-of-type(2) { animation: wc-in 260ms ease-out 110ms both; }
+.wc > section:nth-of-type(3) { animation: wc-in 260ms ease-out 160ms both; }
+.wc > section:nth-of-type(4) { animation: wc-in 260ms ease-out 210ms both; }
+.wc-foot     { animation: wc-in 260ms ease-out 260ms both; }
 
 @keyframes wc-in {
-  from { opacity: 0; transform: translateY(3px); }
+  from { opacity: 0; transform: translateY(4px); }
   to   { opacity: 1; transform: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .wc-head, .wc-status, .wc-actions, .wc-links, .wc-foot { animation: none; }
-  .wc-prompt-caret { animation: none; opacity: 1; }
+  .wc-head, .wc-card, .wc > section, .wc-foot { animation: none; }
 }

--- a/media/webview/welcome/welcome.js
+++ b/media/webview/welcome/welcome.js
@@ -58,26 +58,29 @@ function wireLinks() {
 function renderUsage(usage) {
   if (!usage) return;
 
-  const progress  = getById('usage-progress');
-  const fill      = getById('usage-fill');
-  const text      = getById('usage-text');
-  const limit     = getById('usage-limit');
-  const badge     = getById('subscription-badge');
-  const footMode  = getById('foot-mode');
+  const progress = getById('usage-progress');
+  const fill     = getById('usage-fill');
+  const text     = getById('usage-text');
+  const limit    = getById('usage-limit');
+  const badge    = getById('subscription-badge');
+  const upgrade  = getById('link-upgrade');
 
   if (usage.subscribed) {
     badge.className = 'tag tag-pro';
-    badge.innerHTML = '<span class="dot"></span>pro';
+    badge.innerHTML = '<span class="dot"></span>Pro';
     if (progress) progress.classList.add('hidden');
-    text.textContent  = `${usage.diagramsCreated} diagrams generated`;
-    limit.textContent = '∞';
-    if (footMode) footMode.textContent = 'pro';
+    if (upgrade)  upgrade.classList.add('hidden');
+    text.textContent  = `${usage.diagramsCreated} diagrams created`;
+    limit.textContent = 'Unlimited';
   } else {
     badge.className = 'tag';
-    badge.innerHTML = '<span class="dot"></span>free';
+    badge.innerHTML = '<span class="dot"></span>Free';
     if (progress) progress.classList.remove('hidden');
+    if (upgrade)  upgrade.classList.remove('hidden');
 
-    const pct = Math.min(100, (usage.diagramsCreated / usage.freeLimit) * 100);
+    const used = usage.diagramsCreated;
+    const total = usage.freeLimit;
+    const pct = Math.min(100, (used / total) * 100);
     if (fill) {
       fill.style.width = `${pct}%`;
       fill.classList.remove('warn', 'err');
@@ -85,8 +88,8 @@ function renderUsage(usage) {
       else if (pct >= 70) fill.classList.add('warn');
     }
 
-    text.textContent  = `[${usage.diagramsCreated}/${usage.freeLimit}] diagrams`;
-    limit.textContent = `${Math.max(0, usage.freeLimit - usage.diagramsCreated)} left`;
-    if (footMode) footMode.textContent = 'byok';
+    const remaining = Math.max(0, total - used);
+    text.textContent  = `${used} of ${total} diagrams used`;
+    limit.textContent = remaining === 1 ? '1 left' : `${remaining} left`;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flowcraft",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flowcraft",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "@types/vscode": "^1.95.0",
         "@vscode/webview-ui-toolkit": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/shagunmistry/FlowCraft-VsCode-Extension.git"
   },
   "icon": "FlowCraftLogo_New.png",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [[ -z "${VSCE_PAT:-}" ]]; then
+  echo "error: VSCE_PAT is not set (Azure DevOps PAT for the FlowCraft publisher)" >&2
+  exit 1
+fi
+
+BUMP="${1:-patch}"
+
+npm ci
+npm run compile
+node scripts/copy-webview-files.js
+npm run lint
+
+npx vsce publish "$BUMP"

--- a/src/api/flowcraft-client.ts
+++ b/src/api/flowcraft-client.ts
@@ -78,7 +78,8 @@ export class FlowCraftClient {
       type: this.mapDiagramType(params.type),
       colorPalette: params.colorPalette || 'brand colors',
       complexityLevel: params.complexityLevel || 'medium',
-      is_public: params.isPublic
+      is_public: params.isPublic,
+      model: params.model
     };
 
     const response = await this.makeRequest<DiagramGenerationResponse>(
@@ -114,7 +115,8 @@ export class FlowCraftClient {
       type: 'infographic',
       colorPalette: params.colorPalette || 'brand colors',
       complexityLevel: params.complexityLevel || 'medium',
-      is_public: params.isPublic
+      is_public: params.isPublic,
+      model: params.model
     };
 
     const response = await this.makeRequest<InfographicResponse>(
@@ -150,7 +152,8 @@ export class FlowCraftClient {
       type: 'illustration',
       colorPalette: params.colorPalette || 'brand colors',
       complexityLevel: params.complexityLevel || 'medium',
-      is_public: params.isPublic
+      is_public: params.isPublic,
+      model: params.model
     };
 
     const response = await this.makeRequest<IllustrationResponse>(

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -9,6 +9,7 @@ export interface DiagramGenerationRequest {
   colorPalette?: string;
   complexityLevel?: string;
   is_public: boolean;
+  model?: string;
 }
 
 export interface InfographicRequest {
@@ -17,6 +18,7 @@ export interface InfographicRequest {
   colorPalette?: string;
   complexityLevel?: string;
   is_public: boolean;
+  model?: string;
 }
 
 export interface IllustrationRequest {
@@ -25,6 +27,7 @@ export interface IllustrationRequest {
   colorPalette?: string;
   complexityLevel?: string;
   is_public: boolean;
+  model?: string;
 }
 
 export interface ImageGenerationRequest {

--- a/src/services/diagram-service.ts
+++ b/src/services/diagram-service.ts
@@ -62,18 +62,25 @@ export class DiagramService {
       throw new Error('Usage limit reached. Please upgrade to continue.');
     }
 
+    // Resolve chosen model: explicit param > per-provider setting > server default (undefined).
+    const providerModels = this.stateManager.getSetting('providerModels') || {};
+    const effectiveParams: GenerateDiagramParams = {
+      ...params,
+      model: params.model ?? providerModels[provider]
+    };
+
     let result: DiagramResult | ImageResult;
     let category: DiagramCategory;
 
     // Determine which API endpoint to use based on diagram type
     switch (params.type) {
       case DiagramType.Infographic:
-        result = await this.apiClient.generateInfographic(params, provider, apiKey);
+        result = await this.apiClient.generateInfographic(effectiveParams, provider, apiKey);
         category = DiagramCategory.SVG;
         break;
 
       case DiagramType.Illustration:
-        result = await this.apiClient.generateIllustration(params, provider, apiKey);
+        result = await this.apiClient.generateIllustration(effectiveParams, provider, apiKey);
         category = DiagramCategory.Image;
         break;
 
@@ -83,7 +90,7 @@ export class DiagramService {
 
       default:
         // Mermaid diagrams
-        result = await this.apiClient.generateDiagram(params, provider, apiKey);
+        result = await this.apiClient.generateDiagram(effectiveParams, provider, apiKey);
         category = DiagramCategory.Mermaid;
     }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -91,32 +91,54 @@ export const PROVIDER_INFO: Record<Provider, ProviderInfo> = {
     provider: Provider.OpenAI,
     displayName: 'OpenAI',
     requiresApiKey: true,
-    supportedModels: ['gpt-4', 'gpt-4-turbo', 'gpt-3.5-turbo'],
-    defaultModel: 'gpt-4',
+    supportedModels: ['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'o1-mini', 'o3-mini'],
+    defaultModel: 'gpt-4o',
     features: ['diagrams', 'infographics']
   },
   [Provider.Anthropic]: {
     provider: Provider.Anthropic,
     displayName: 'Anthropic (Claude)',
     requiresApiKey: true,
-    supportedModels: ['claude-3-opus', 'claude-3-sonnet', 'claude-3-haiku'],
-    defaultModel: 'claude-3-sonnet',
+    supportedModels: [
+      'claude-opus-4-20250514',
+      'claude-sonnet-4-20250514',
+      'claude-haiku-4-20250514',
+      'claude-3-7-sonnet-20250219',
+      'claude-3-5-sonnet-20241022',
+      'claude-3-5-haiku-20241022'
+    ],
+    defaultModel: 'claude-sonnet-4-20250514',
     features: ['diagrams', 'infographics']
   },
   [Provider.Google]: {
     provider: Provider.Google,
     displayName: 'Google (Gemini)',
     requiresApiKey: true,
-    supportedModels: ['gemini-pro', 'gemini-pro-vision'],
-    defaultModel: 'gemini-pro',
+    supportedModels: ['gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-1.5-pro', 'gemini-1.5-flash'],
+    defaultModel: 'gemini-2.5-flash',
     features: ['diagrams']
   },
   [Provider.FlowCraft]: {
     provider: Provider.FlowCraft,
     displayName: 'FlowCraft API',
     requiresApiKey: true,
-    supportedModels: ['flowcraft-v2'],
-    defaultModel: 'flowcraft-v2',
+    supportedModels: ['flowcraft-default'],
+    defaultModel: 'flowcraft-default',
     features: ['diagrams', 'infographics', 'illustrations', 'images']
   }
 };
+
+/**
+ * Returns the curated list of models available for a given provider.
+ * Used by the Settings webview to populate the per-provider model picker.
+ */
+export function getSupportedModels(provider: Provider): string[] {
+  return PROVIDER_INFO[provider]?.supportedModels ?? [];
+}
+
+/**
+ * Returns the default model for a given provider.
+ */
+export function getDefaultModel(provider: Provider): string {
+  return PROVIDER_INFO[provider]?.defaultModel ?? '';
+}

--- a/src/types/diagram.ts
+++ b/src/types/diagram.ts
@@ -75,6 +75,8 @@ export interface GenerateDiagramParams {
   colorPalette?: string;
   complexityLevel?: 'simple' | 'medium' | 'complex';
   isPublic: boolean;
+  /** Optional LLM model id (e.g. "gpt-4o", "claude-sonnet-4-20250514"). */
+  model?: string;
 }
 
 export interface GenerateImageParams {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -28,6 +28,10 @@ export interface Settings {
     [Provider.FlowCraft]?: ProviderConfig;
   };
 
+  // Model selection per provider — each provider gets its own chosen model.
+  // When a provider has no entry here, the API falls back to its server-side default.
+  providerModels: Partial<Record<Provider, string>>;
+
   // Diagram Defaults
   defaultDiagramType: string;
   defaultColorPalette: string;
@@ -61,6 +65,7 @@ export interface ProviderStatus {
 export const DEFAULT_SETTINGS: Settings = {
   defaultProvider: Provider.OpenAI,
   providers: {},
+  providerModels: {},
   defaultDiagramType: 'flowchart',
   defaultColorPalette: 'brand colors',
   defaultComplexity: 'medium',

--- a/src/webview/settings/index.html
+++ b/src/webview/settings/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src {{cspSource}} 'unsafe-inline'; script-src 'nonce-{{nonce}}'; img-src {{cspSource}} https: data:;">
-    <title>FlowCraft · settings</title>
+    <title>FlowCraft · Settings</title>
 
     <link rel="stylesheet" href="{{themeCss}}">
     <link rel="stylesheet" href="{{componentsCss}}">
@@ -15,144 +15,198 @@
     <main class="st">
 
         <header class="st-head">
-            <div class="st-path">
-                <span class="muted">flowcraft</span>
-                <span class="dim">/</span>
-                <span>settings.toml</span>
+            <div class="st-head-text">
+                <h1 class="st-title">Settings</h1>
+                <p class="st-subtitle">Connect a provider and set your defaults. Your keys stay on this machine.</p>
             </div>
-            <div class="st-actions">
-                <button class="btn-icon" id="reveal-btn" title="show / hide keys">
+            <div class="st-head-actions">
+                <button class="btn-icon" id="reveal-btn" title="Show or hide API keys" aria-label="Show or hide API keys">
                     <i class="codicon codicon-eye"></i>
                 </button>
-                <button class="btn-icon" id="reset-btn" title="reset to defaults (⌘R)">
+                <button class="btn-icon" id="reset-btn" title="Reset to defaults (⌘R)" aria-label="Reset to defaults">
                     <i class="codicon codicon-debug-restart"></i>
                 </button>
             </div>
         </header>
 
-        <!-- ————— providers ————— -->
-        <section class="st-section">
-            <span class="section-marker">providers · byok</span>
+        <!-- ————— API Providers ————— -->
+        <section class="st-section" aria-labelledby="providers-heading">
+            <div class="st-section-head">
+                <h2 id="providers-heading" class="st-section-title">API providers</h2>
+                <p class="st-section-desc">Bring your own key. Add at least one to start generating.</p>
+            </div>
 
-            <!-- OpenAI -->
-            <div class="row">
-                <div class="row-head">
-                    <span class="row-key"><span class="prefix">api.</span>openai</span>
-                    <span class="row-hint">gpt-4o · gpt-4 · gpt-3.5 · prefix <code>sk-</code></span>
+            <div class="st-card">
+                <div class="st-provider">
+                    <div class="st-provider-head">
+                        <div class="st-provider-id">
+                            <span class="st-provider-name">OpenAI</span>
+                            <span id="status-openai" class="st-status">Not connected</span>
+                        </div>
+                        <span class="st-provider-hint">GPT-4o · GPT-4 · starts with <code>sk-</code></span>
+                    </div>
+                    <div class="st-provider-control">
+                        <input type="password" class="input" id="key-openai" placeholder="sk-…" autocomplete="off" spellcheck="false">
+                        <button class="btn btn-sm" id="test-openai">Test</button>
+                    </div>
                 </div>
-                <div class="row-control">
-                    <input type="password" class="input" id="key-openai" placeholder="sk-…" autocomplete="off" spellcheck="false">
-                    <button class="btn btn-sm" id="test-openai">test</button>
+
+                <div class="st-provider">
+                    <div class="st-provider-head">
+                        <div class="st-provider-id">
+                            <span class="st-provider-name">Anthropic</span>
+                            <span id="status-anthropic" class="st-status">Not connected</span>
+                        </div>
+                        <span class="st-provider-hint">Claude Opus · Sonnet · Haiku · starts with <code>sk-ant-</code></span>
+                    </div>
+                    <div class="st-provider-control">
+                        <input type="password" class="input" id="key-anthropic" placeholder="sk-ant-…" autocomplete="off" spellcheck="false">
+                        <button class="btn btn-sm" id="test-anthropic">Test</button>
+                    </div>
                 </div>
-                <div class="row-foot">
-                    <span id="status-openai" class="status">unset</span>
-                    <span class="dim">stored in vscode.secrets</span>
+
+                <div class="st-provider">
+                    <div class="st-provider-head">
+                        <div class="st-provider-id">
+                            <span class="st-provider-name">Google</span>
+                            <span id="status-google" class="st-status">Not connected</span>
+                        </div>
+                        <span class="st-provider-hint">Gemini Pro · starts with <code>AIza</code></span>
+                    </div>
+                    <div class="st-provider-control">
+                        <input type="password" class="input" id="key-google" placeholder="AIza…" autocomplete="off" spellcheck="false">
+                        <button class="btn btn-sm" id="test-google">Test</button>
+                    </div>
+                </div>
+
+                <div class="st-provider">
+                    <div class="st-provider-head">
+                        <div class="st-provider-id">
+                            <span class="st-provider-name">FlowCraft</span>
+                            <span id="status-flowcraft" class="st-status">Not connected</span>
+                        </div>
+                        <span class="st-provider-hint">FlowCraft hosted · starts with <code>fc_</code></span>
+                    </div>
+                    <div class="st-provider-control">
+                        <input type="password" class="input" id="key-flowcraft" placeholder="fc_…" autocomplete="off" spellcheck="false">
+                        <button class="btn btn-sm" id="test-flowcraft">Test</button>
+                    </div>
                 </div>
             </div>
 
-            <!-- Anthropic -->
-            <div class="row">
-                <div class="row-head">
-                    <span class="row-key"><span class="prefix">api.</span>anthropic</span>
-                    <span class="row-hint">claude 3 opus · sonnet · haiku · prefix <code>sk-ant-</code></span>
-                </div>
-                <div class="row-control">
-                    <input type="password" class="input" id="key-anthropic" placeholder="sk-ant-…" autocomplete="off" spellcheck="false">
-                    <button class="btn btn-sm" id="test-anthropic">test</button>
-                </div>
-                <div class="row-foot">
-                    <span id="status-anthropic" class="status">unset</span>
-                    <span class="dim">stored in vscode.secrets</span>
-                </div>
+            <p class="st-footnote"><i class="codicon codicon-shield"></i> Keys are stored securely in VS Code's secret storage — never synced or shared.</p>
+        </section>
+
+        <!-- ————— Defaults ————— -->
+        <section class="st-section" aria-labelledby="defaults-heading">
+            <div class="st-section-head">
+                <h2 id="defaults-heading" class="st-section-title">Defaults</h2>
+                <p class="st-section-desc">Pre-fills used when creating a new diagram.</p>
             </div>
 
-            <!-- Google -->
-            <div class="row">
-                <div class="row-head">
-                    <span class="row-key"><span class="prefix">api.</span>google</span>
-                    <span class="row-hint">gemini pro · prefix <code>AIza</code></span>
+            <div class="st-card">
+                <div class="st-field">
+                    <label class="st-field-label" for="default-provider">
+                        <span class="st-field-name">Active provider</span>
+                        <span class="st-field-hint">Which provider handles your requests</span>
+                    </label>
+                    <select class="input" id="default-provider">
+                        <option value="openai">OpenAI</option>
+                        <option value="anthropic">Anthropic</option>
+                        <option value="google">Google</option>
+                        <option value="flowcraft">FlowCraft</option>
+                    </select>
                 </div>
-                <div class="row-control">
-                    <input type="password" class="input" id="key-google" placeholder="AIza…" autocomplete="off" spellcheck="false">
-                    <button class="btn btn-sm" id="test-google">test</button>
-                </div>
-                <div class="row-foot">
-                    <span id="status-google" class="status">unset</span>
-                    <span class="dim">stored in vscode.secrets</span>
-                </div>
-            </div>
 
-            <!-- FlowCraft -->
-            <div class="row">
-                <div class="row-head">
-                    <span class="row-key"><span class="prefix">api.</span>flowcraft</span>
-                    <span class="row-hint">native cloud · prefix <code>fc_</code></span>
+                <div class="st-field">
+                    <label class="st-field-label" for="default-type">
+                        <span class="st-field-name">Diagram type</span>
+                        <span class="st-field-hint">Default style for new diagrams</span>
+                    </label>
+                    <select class="input" id="default-type">
+                        <option value="flowchart">Flowchart</option>
+                        <option value="sequence">Sequence</option>
+                        <option value="class">Class</option>
+                        <option value="state">State</option>
+                        <option value="er">Entity-Relationship</option>
+                        <option value="gantt">Gantt</option>
+                        <option value="pie">Pie chart</option>
+                    </select>
                 </div>
-                <div class="row-control">
-                    <input type="password" class="input" id="key-flowcraft" placeholder="fc_…" autocomplete="off" spellcheck="false">
-                    <button class="btn btn-sm" id="test-flowcraft">test</button>
+
+                <div class="st-field">
+                    <label class="st-field-label" for="default-palette">
+                        <span class="st-field-name">Color palette</span>
+                        <span class="st-field-hint">How new diagrams are colored</span>
+                    </label>
+                    <select class="input" id="default-palette">
+                        <option value="brand colors">Brand</option>
+                        <option value="monochromatic">Monochromatic</option>
+                        <option value="complementary">Complementary</option>
+                        <option value="analogous">Analogous</option>
+                    </select>
                 </div>
-                <div class="row-foot">
-                    <span id="status-flowcraft" class="status">unset</span>
-                    <span class="dim">stored in vscode.secrets</span>
+
+                <div class="st-field">
+                    <label class="st-field-label" for="default-complexity">
+                        <span class="st-field-name">Detail level</span>
+                        <span class="st-field-hint">How much the model elaborates</span>
+                    </label>
+                    <select class="input" id="default-complexity">
+                        <option value="simple">Simple</option>
+                        <option value="medium">Medium</option>
+                        <option value="complex">Detailed</option>
+                    </select>
                 </div>
             </div>
         </section>
 
-        <!-- ————— preferences ————— -->
-        <section class="st-section">
-            <span class="section-marker">defaults</span>
-
-            <div class="row row-inline">
-                <span class="row-key"><span class="prefix">default.</span>provider</span>
-                <select class="input input-inline" id="default-provider">
-                    <option value="openai">openai</option>
-                    <option value="anthropic">anthropic</option>
-                    <option value="google">google</option>
-                    <option value="flowcraft">flowcraft</option>
-                </select>
+        <!-- ————— Models per provider ————— -->
+        <section class="st-section" aria-labelledby="models-heading">
+            <div class="st-section-head">
+                <h2 id="models-heading" class="st-section-title">Model overrides</h2>
+                <p class="st-section-desc">Pick a specific model for each provider. Leave on <em>Default</em> to let FlowCraft choose.</p>
             </div>
 
-            <div class="row row-inline">
-                <span class="row-key"><span class="prefix">default.</span>diagram</span>
-                <select class="input input-inline" id="default-type">
-                    <option value="flowchart">flowchart</option>
-                    <option value="sequence">sequence</option>
-                    <option value="class">class</option>
-                    <option value="state">state</option>
-                    <option value="er">er</option>
-                    <option value="gantt">gantt</option>
-                    <option value="pie">pie</option>
-                </select>
-            </div>
+            <div class="st-card">
+                <div class="st-field">
+                    <label class="st-field-label" for="model-openai">
+                        <span class="st-field-name">OpenAI</span>
+                    </label>
+                    <select class="input" id="model-openai" data-provider="openai"></select>
+                </div>
 
-            <div class="row row-inline">
-                <span class="row-key"><span class="prefix">default.</span>palette</span>
-                <select class="input input-inline" id="default-palette">
-                    <option value="brand colors">brand</option>
-                    <option value="monochromatic">monochromatic</option>
-                    <option value="complementary">complementary</option>
-                    <option value="analogous">analogous</option>
-                </select>
-            </div>
+                <div class="st-field">
+                    <label class="st-field-label" for="model-anthropic">
+                        <span class="st-field-name">Anthropic</span>
+                    </label>
+                    <select class="input" id="model-anthropic" data-provider="anthropic"></select>
+                </div>
 
-            <div class="row row-inline">
-                <span class="row-key"><span class="prefix">default.</span>complexity</span>
-                <select class="input input-inline" id="default-complexity">
-                    <option value="simple">simple</option>
-                    <option value="medium">medium</option>
-                    <option value="complex">complex</option>
-                </select>
+                <div class="st-field">
+                    <label class="st-field-label" for="model-google">
+                        <span class="st-field-name">Google</span>
+                    </label>
+                    <select class="input" id="model-google" data-provider="google"></select>
+                </div>
+
+                <div class="st-field">
+                    <label class="st-field-label" for="model-flowcraft">
+                        <span class="st-field-name">FlowCraft</span>
+                    </label>
+                    <select class="input" id="model-flowcraft" data-provider="flowcraft"></select>
+                </div>
             </div>
         </section>
 
     </main>
 
     <footer class="st-foot">
-        <span class="st-foot-cell"><span class="dim">⌘S</span> save</span>
-        <span class="st-foot-cell"><span class="dim">⌘R</span> reset</span>
-        <span class="st-foot-cell" id="foot-status">idle</span>
-        <button class="btn btn-primary" id="save-btn">save changes</button>
+        <span class="st-foot-status" id="foot-status">No unsaved changes</span>
+        <div class="st-foot-actions">
+            <span class="st-foot-hint"><kbd>⌘S</kbd> to save</span>
+            <button class="btn btn-primary" id="save-btn">Save changes</button>
+        </div>
     </footer>
 
     <script type="module" nonce="{{nonce}}" src="{{settingsJs}}"></script>

--- a/src/webview/settings/settings.css
+++ b/src/webview/settings/settings.css
@@ -1,114 +1,299 @@
-/* Settings — config-file layout */
+/* Settings — refined panel, Apple/Airbnb-inspired */
+
+:root {
+  --st-radius: 12px;
+  --st-radius-sm: 8px;
+  --st-font-ui: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", system-ui, sans-serif);
+  --st-fs-title: 22px;
+  --st-fs-section: 15px;
+  --st-fs-field: 13px;
+  --st-fs-body: 12.5px;
+  --st-fs-label: 11px;
+  --st-pad: 20px;
+}
 
 body { padding: 0; overflow-x: hidden; }
 
 .st {
-  padding: var(--fc-sp-5);
-  padding-bottom: 72px; /* room for sticky footer */
+  padding: 24px var(--st-pad) 96px;
   display: flex;
   flex-direction: column;
-  gap: var(--fc-sp-7);
-  max-width: 820px;
+  gap: 32px;
+  max-width: 720px;
   margin: 0 auto;
+  font-family: var(--st-font-ui);
+  font-size: var(--st-fs-body);
+  line-height: 1.5;
+  letter-spacing: 0;
 }
+.st * { font-family: var(--st-font-ui); }
+.st code, .st kbd { font-family: var(--fc-font-mono); }
 
-/* Head ——————————————————————————— */
+/* Header ——————————————————————————— */
 .st-head {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: var(--fc-sp-4);
-  padding-bottom: var(--fc-sp-4);
-  border-bottom: 1px dashed var(--fc-border);
+  gap: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--fc-border);
 }
-.st-path {
-  font-family: var(--fc-font-mono);
-  font-size: var(--fc-fs-md);
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
+.st-head-text { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.st-title {
+  font-size: var(--st-fs-title);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--fc-fg);
+  text-transform: none;
+  line-height: 1.2;
 }
-.st-path .dim { color: var(--fc-fg-dim); }
-.st-actions { display: inline-flex; gap: var(--fc-sp-2); }
+.st-subtitle {
+  font-size: var(--st-fs-body);
+  color: var(--fc-fg-muted);
+  line-height: 1.4;
+  max-width: 440px;
+}
+.st-head-actions { display: inline-flex; gap: 4px; flex-shrink: 0; }
+.st-head-actions .btn-icon { width: 30px; height: 30px; border-radius: var(--st-radius-sm); }
 
-/* Sections ——————————————————————————— */
+/* Section ——————————————————————————— */
 .st-section {
   display: flex;
   flex-direction: column;
+  gap: 14px;
 }
+.st-section-head { display: flex; flex-direction: column; gap: 4px; padding: 0 2px; }
+.st-section-title {
+  font-size: var(--st-fs-section);
+  font-weight: 600;
+  color: var(--fc-fg);
+  letter-spacing: -0.01em;
+  text-transform: none;
+}
+.st-section-desc {
+  font-size: var(--st-fs-body);
+  color: var(--fc-fg-muted);
+  line-height: 1.4;
+}
+.st-section-desc em { font-style: normal; color: var(--fc-fg); font-weight: 500; }
 
-/* Row overrides ——————————————————————————— */
-.row code {
-  padding: 0 3px;
+/* Card ——————————————————————————— */
+.st-card {
   background: var(--fc-surface);
   border: 1px solid var(--fc-border);
-  border-radius: 2px;
-  color: var(--fc-fg);
-  font-size: 10px;
+  border-radius: var(--st-radius);
+  overflow: hidden;
 }
 
-.row-inline {
-  display: grid;
-  grid-template-columns: minmax(200px, 1fr) auto;
-  align-items: center;
-  padding: var(--fc-sp-4) 0;
-  gap: var(--fc-sp-5);
+/* Provider rows (in card) ——————————————————————————— */
+.st-provider {
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-bottom: 1px solid var(--fc-border);
 }
-.row-inline .row-key {
-  display: inline-flex;
+.st-provider:last-child { border-bottom: none; }
+
+.st-provider-head {
+  display: flex;
   align-items: baseline;
-  gap: 4px;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 6px 12px;
 }
-.input-inline {
-  width: auto;
-  min-width: 160px;
-  padding: var(--fc-sp-2) var(--fc-sp-4);
-  padding-right: 28px;
+.st-provider-id {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
 }
-
-/* Status text ——————————————————————————— */
-.status {
-  font-family: var(--fc-font-mono);
-  font-size: var(--fc-fs-sm);
+.st-provider-name {
+  font-size: var(--st-fs-field);
+  font-weight: 600;
+  color: var(--fc-fg);
+}
+.st-provider-hint {
+  font-size: var(--st-fs-label);
   color: var(--fc-fg-muted);
+  line-height: 1.4;
 }
-.status.ok  { color: var(--fc-ok); }
-.status.err { color: var(--fc-err); }
-.status.warn { color: var(--fc-warn); }
-.status::before {
-  content: "● ";
-  color: currentColor;
-  opacity: 0.75;
+.st-provider-hint code {
+  padding: 1px 5px;
+  background: var(--fc-bg-alt);
+  border: 1px solid var(--fc-border);
+  border-radius: 4px;
+  color: var(--fc-fg);
+  font-size: 10.5px;
 }
 
-/* Footer action bar (sticky) ——————————————————————————— */
+.st-provider-control {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.st-provider-control .input {
+  flex: 1;
+  padding: 8px 10px;
+  border-radius: var(--st-radius-sm);
+  font-family: var(--fc-font-mono);
+  font-size: 12px;
+}
+.st-provider-control .btn {
+  border-radius: var(--st-radius-sm);
+  padding: 7px 14px;
+  font-weight: 500;
+  font-family: var(--st-font-ui);
+}
+
+/* Status pill ——————————————————————————— */
+.st-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: var(--st-fs-label);
+  font-weight: 500;
+  color: var(--fc-fg-muted);
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--fc-bg-alt);
+  border: 1px solid var(--fc-border);
+}
+.st-status::before {
+  content: "";
+  display: inline-block;
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--fc-fg-dim);
+}
+.st-status.ok    { color: var(--fc-ok);   border-color: color-mix(in srgb, var(--fc-ok) 35%, transparent); background: color-mix(in srgb, var(--fc-ok) 10%, transparent); }
+.st-status.ok::before { background: var(--fc-ok); }
+.st-status.err   { color: var(--fc-err);  border-color: color-mix(in srgb, var(--fc-err) 35%, transparent); background: color-mix(in srgb, var(--fc-err) 10%, transparent); }
+.st-status.err::before { background: var(--fc-err); }
+.st-status.warn  { color: var(--fc-warn); border-color: color-mix(in srgb, var(--fc-warn) 35%, transparent); background: color-mix(in srgb, var(--fc-warn) 10%, transparent); }
+.st-status.warn::before { background: var(--fc-warn); }
+
+/* Field (preferences, models) ——————————————————————————— */
+.st-field {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(180px, 220px);
+  align-items: center;
+  gap: 16px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--fc-border);
+}
+.st-field:last-child { border-bottom: none; }
+
+.st-field-label {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  cursor: pointer;
+}
+.st-field-name {
+  font-size: var(--st-fs-field);
+  font-weight: 500;
+  color: var(--fc-fg);
+}
+.st-field-hint {
+  font-size: var(--st-fs-body);
+  color: var(--fc-fg-muted);
+  line-height: 1.35;
+}
+
+.st-field .input {
+  padding: 7px 28px 7px 10px;
+  border-radius: var(--st-radius-sm);
+  font-family: var(--st-font-ui);
+  font-size: var(--st-fs-field);
+}
+
+@media (max-width: 520px) {
+  .st-field {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+  .st-field .input { width: 100%; }
+}
+
+/* Footnote ——————————————————————————— */
+.st-footnote {
+  font-size: var(--st-fs-label);
+  color: var(--fc-fg-muted);
+  padding: 0 4px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  line-height: 1.4;
+}
+.st-footnote i { font-size: 13px; color: var(--fc-fg-dim); }
+
+/* Sticky footer ——————————————————————————— */
 .st-foot {
   position: fixed;
   left: 0; right: 0; bottom: 0;
   display: flex;
   align-items: center;
-  gap: var(--fc-sp-5);
-  padding: var(--fc-sp-3) var(--fc-sp-5);
-  background: color-mix(in srgb, var(--fc-bg) 88%, transparent);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px var(--st-pad);
+  background: color-mix(in srgb, var(--fc-bg) 92%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
   border-top: 1px solid var(--fc-border);
-  font-family: var(--fc-font-mono);
-  font-size: var(--fc-fs-sm);
+  font-family: var(--st-font-ui);
+  font-size: var(--st-fs-body);
   color: var(--fc-fg-muted);
   z-index: 10;
 }
-.st-foot-cell { display: inline-flex; align-items: center; gap: 6px; }
-.st-foot .dim { color: var(--fc-fg-dim); }
-.st-foot #save-btn { margin-left: auto; }
+.st-foot-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.st-foot-status.ok { color: var(--fc-ok); }
+.st-foot-status.err { color: var(--fc-err); }
 
-/* Entrance */
-.st-head, .st-section { animation: st-in 220ms ease-out both; }
-.st-section:nth-of-type(2) { animation-delay: 40ms; }
-.st-section:nth-of-type(3) { animation-delay: 80ms; }
+.st-foot-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+.st-foot-hint {
+  font-size: var(--st-fs-label);
+  color: var(--fc-fg-dim);
+}
+.st-foot-hint kbd {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 4px;
+  border: 1px solid var(--fc-border);
+  background: var(--fc-bg-alt);
+  color: var(--fc-fg-muted);
+}
+.st-foot #save-btn {
+  border-radius: var(--st-radius-sm);
+  padding: 8px 18px;
+  font-weight: 600;
+  font-family: var(--st-font-ui);
+  font-size: var(--st-fs-field);
+}
+
+/* Entrance ——————————————————————————— */
+.st-head     { animation: st-in 260ms ease-out both; }
+.st-section  { animation: st-in 260ms ease-out both; }
+.st-section:nth-of-type(1) { animation-delay: 60ms; }
+.st-section:nth-of-type(2) { animation-delay: 110ms; }
+.st-section:nth-of-type(3) { animation-delay: 160ms; }
 
 @keyframes st-in {
-  from { opacity: 0; transform: translateY(3px); }
+  from { opacity: 0; transform: translateY(4px); }
   to   { opacity: 1; transform: none; }
 }
 

--- a/src/webview/settings/settings.js
+++ b/src/webview/settings/settings.js
@@ -3,6 +3,22 @@ import { getById, queryAll } from '../shared/utils/dom.js';
 
 const PROVIDERS = ['openai', 'anthropic', 'google', 'flowcraft'];
 
+// Curated model lists per provider — mirrors PROVIDER_INFO in src/types/api.ts.
+// Keep in sync when the TypeScript list changes.
+const MODELS_BY_PROVIDER = {
+  openai: ['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'o1-mini', 'o3-mini'],
+  anthropic: [
+    'claude-opus-4-20250514',
+    'claude-sonnet-4-20250514',
+    'claude-haiku-4-20250514',
+    'claude-3-7-sonnet-20250219',
+    'claude-3-5-sonnet-20241022',
+    'claude-3-5-haiku-20241022'
+  ],
+  google: ['gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-1.5-pro', 'gemini-1.5-flash'],
+  flowcraft: ['flowcraft-default']
+};
+
 let currentSettings = {};
 let currentProviders = {};
 let keysRevealed = false;
@@ -18,22 +34,22 @@ document.addEventListener('DOMContentLoaded', () => {
       render();
     },
     connectionResult: ({ provider, success, message }) => {
-      setStatus(provider, success ? 'ok' : 'err', success ? 'verified' : (message || 'failed'));
+      setStatus(provider, success ? 'ok' : 'err', success ? 'Connected' : (message || 'Failed to connect'));
       const btn = getById(`test-${provider}`);
-      if (btn) { btn.disabled = false; btn.textContent = 'test'; }
+      if (btn) { btn.disabled = false; btn.textContent = 'Test'; }
     },
     saveComplete: ({ success }) => {
       const btn = getById('save-btn');
       const foot = getById('foot-status');
       if (btn) {
-        btn.textContent = success ? 'saved' : 'save failed';
+        btn.textContent = success ? 'Saved' : 'Save failed';
         btn.disabled = false;
-        setTimeout(() => { btn.textContent = 'save changes'; }, 1400);
+        setTimeout(() => { btn.textContent = 'Save changes'; }, 1400);
       }
       if (foot) {
-        foot.textContent = success ? 'changes written' : 'write failed';
-        foot.className = 'st-foot-cell ' + (success ? 'ok' : 'err');
-        setTimeout(() => { foot.textContent = 'idle'; foot.className = 'st-foot-cell'; }, 1800);
+        foot.textContent = success ? 'Changes saved' : 'Could not save changes';
+        foot.className = 'st-foot-status ' + (success ? 'ok' : 'err');
+        setTimeout(() => { foot.textContent = 'No unsaved changes'; foot.className = 'st-foot-status'; }, 2000);
       }
     }
   });
@@ -48,12 +64,12 @@ function wire() {
       const input = getById(`key-${provider}`);
       const apiKey = input && input.value;
       if (!apiKey) {
-        setStatus(provider, 'err', 'enter a key first');
+        setStatus(provider, 'err', 'Enter a key first');
         return;
       }
       btn.disabled = true;
-      btn.textContent = '…';
-      setStatus(provider, 'warn', 'checking…');
+      btn.textContent = 'Testing…';
+      setStatus(provider, 'warn', 'Checking…');
       postMessage('testConnection', { provider, apiKey });
     });
   });
@@ -63,7 +79,7 @@ function wire() {
 
   // Reset
   getById('reset-btn')?.addEventListener('click', () => {
-    if (confirm('reset all settings to defaults?')) postMessage('resetSettings');
+    if (confirm('Reset all settings to their defaults? Your API keys will be kept.')) postMessage('resetSettings');
   });
 
   // Reveal / hide passwords
@@ -79,13 +95,22 @@ function wire() {
   document.addEventListener('keydown', (e) => {
     const mod = e.metaKey || e.ctrlKey;
     if (mod && e.key === 's') { e.preventDefault(); save(); }
-    if (mod && e.key === 'r') { e.preventDefault(); if (confirm('reset all settings to defaults?')) postMessage('resetSettings'); }
+    if (mod && e.key === 'r') { e.preventDefault(); if (confirm('Reset all settings to their defaults? Your API keys will be kept.')) postMessage('resetSettings'); }
   });
 }
 
 function save() {
   const btn = getById('save-btn');
-  if (btn) { btn.disabled = true; btn.textContent = 'saving…'; }
+  if (btn) { btn.disabled = true; btn.textContent = 'Saving…'; }
+
+  const providerModels = { ...(currentSettings.providerModels || {}) };
+  PROVIDERS.forEach(p => {
+    const sel = getById(`model-${p}`);
+    if (!sel) return;
+    const v = sel.value;
+    if (!v) delete providerModels[p];
+    else providerModels[p] = v;
+  });
 
   const newSettings = {
     ...currentSettings,
@@ -93,6 +118,7 @@ function save() {
     defaultDiagramType:  getById('default-type').value,
     defaultColorPalette: getById('default-palette').value,
     defaultComplexity:   getById('default-complexity').value,
+    providerModels
   };
 
   const apiKeys = {};
@@ -108,20 +134,44 @@ function render() {
   if (!currentSettings) return;
 
   Object.entries(currentProviders || {}).forEach(([provider, configured]) => {
-    if (configured) setStatus(provider, 'ok', 'configured');
-    else            setStatus(provider, '',   'unset');
+    if (configured) setStatus(provider, 'ok', 'Connected');
+    else            setStatus(provider, '',   'Not connected');
   });
 
   setSelect('default-provider',   currentSettings.defaultProvider);
   setSelect('default-type',       currentSettings.defaultDiagramType);
   setSelect('default-palette',    currentSettings.defaultColorPalette);
   setSelect('default-complexity', currentSettings.defaultComplexity);
+
+  renderModelSelects();
+}
+
+function renderModelSelects() {
+  const chosen = currentSettings.providerModels || {};
+  PROVIDERS.forEach(p => {
+    const sel = getById(`model-${p}`);
+    if (!sel) return;
+    const models = MODELS_BY_PROVIDER[p] || [];
+    // Build: a "default" option (sends no override), then curated models.
+    sel.innerHTML = '';
+    const defOpt = document.createElement('option');
+    defOpt.value = '';
+    defOpt.textContent = 'Default (recommended)';
+    sel.appendChild(defOpt);
+    models.forEach(m => {
+      const o = document.createElement('option');
+      o.value = m;
+      o.textContent = m;
+      sel.appendChild(o);
+    });
+    sel.value = chosen[p] || '';
+  });
 }
 
 function setStatus(provider, state, text) {
   const el = getById(`status-${provider}`);
   if (!el) return;
-  el.className = 'status' + (state ? ' ' + state : '');
+  el.className = 'st-status' + (state ? ' ' + state : '');
   el.textContent = text;
 }
 

--- a/src/webview/welcome/index.html
+++ b/src/webview/welcome/index.html
@@ -15,98 +15,121 @@
     <main class="wc">
 
         <header class="wc-head">
-            <div class="wc-prompt">
-                <span class="wc-prompt-user">flowcraft</span><span class="wc-prompt-sep">@</span><span class="wc-prompt-host">vscode</span>
-                <span class="wc-prompt-path">~/diagrams</span>
-                <span class="wc-prompt-caret">$</span>
+            <div class="wc-brand">
+                <div class="wc-mark" aria-hidden="true">
+                    <span class="wc-mark-glyph">◈</span>
+                </div>
+                <div class="wc-brand-text">
+                    <h1 class="wc-title">FlowCraft</h1>
+                    <p class="wc-subtitle">Turn code and ideas into clear diagrams.</p>
+                </div>
             </div>
-            <div class="wc-version muted">v2.1.0</div>
         </header>
 
-        <section class="wc-status" aria-label="subscription status">
-            <div class="wc-status-row">
-                <span class="wc-status-label">plan</span>
-                <span id="subscription-badge" class="tag"><span class="dot"></span>free</span>
+        <section class="wc-card wc-plan" aria-label="Subscription and usage">
+            <div class="wc-plan-head">
+                <div class="wc-plan-heading">
+                    <span class="wc-eyebrow">Your plan</span>
+                    <span id="subscription-badge" class="tag"><span class="dot"></span>Free</span>
+                </div>
+                <a href="#" id="link-upgrade" class="wc-upgrade hidden">Upgrade</a>
             </div>
-            <div class="progress" id="usage-progress" aria-hidden="false">
+            <div class="progress" id="usage-progress">
                 <div class="fill" id="usage-fill" style="width: 0%"></div>
             </div>
-            <div class="wc-status-row wc-status-foot">
-                <span id="usage-text" class="mono muted">—</span>
-                <span id="usage-limit" class="mono muted"></span>
+            <div class="wc-plan-foot">
+                <span id="usage-text" class="wc-usage-text">Loading usage…</span>
+                <span id="usage-limit" class="wc-usage-limit"></span>
             </div>
         </section>
 
-        <span class="section-marker">actions</span>
+        <section aria-labelledby="wc-actions-heading">
+            <h2 id="wc-actions-heading" class="wc-section-title">Create</h2>
 
-        <nav class="wc-actions" aria-label="commands">
-            <button class="tile" id="action-diagram" data-key="1">
-                <span class="tile-num">1</span>
-                <span class="tile-body">
-                    <span class="tile-title">generate diagram</span>
-                    <span class="tile-desc">flowchart · sequence · class · er · …</span>
-                </span>
-                <span class="kbd">⌘⇧D</span>
-            </button>
+            <nav class="wc-actions" aria-label="Create actions">
+                <button class="wc-tile" id="action-diagram" data-key="1">
+                    <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-symbol-structure"></i></span>
+                    <span class="wc-tile-body">
+                        <span class="wc-tile-title">Create a diagram</span>
+                        <span class="wc-tile-desc">Flowchart, sequence, class, ER and more</span>
+                    </span>
+                    <span class="kbd">⌘⇧D</span>
+                </button>
 
-            <button class="tile" id="action-selection" data-key="2">
-                <span class="tile-num">2</span>
-                <span class="tile-body">
-                    <span class="tile-title">from selection</span>
-                    <span class="tile-desc">use the highlighted text in the editor</span>
-                </span>
-                <span class="kbd">⌘⇧G</span>
-            </button>
+                <button class="wc-tile" id="action-selection" data-key="2">
+                    <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-selection"></i></span>
+                    <span class="wc-tile-body">
+                        <span class="wc-tile-title">From editor selection</span>
+                        <span class="wc-tile-desc">Generate a diagram from highlighted code</span>
+                    </span>
+                    <span class="kbd">⌘⇧G</span>
+                </button>
 
-            <button class="tile" id="action-infographic" data-key="3">
-                <span class="tile-num">3</span>
-                <span class="tile-body">
-                    <span class="tile-title">infographic <span class="tag">soon</span></span>
-                    <span class="tile-desc">visual data summary</span>
-                </span>
-                <span class="kbd">—</span>
-            </button>
+                <button class="wc-tile" id="action-infographic" data-key="3" disabled>
+                    <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-graph"></i></span>
+                    <span class="wc-tile-body">
+                        <span class="wc-tile-title">Infographic <span class="tag tag-soon">Coming soon</span></span>
+                        <span class="wc-tile-desc">Visual summaries from data or notes</span>
+                    </span>
+                </button>
 
-            <button class="tile" id="action-image" data-key="4">
-                <span class="tile-num">4</span>
-                <span class="tile-body">
-                    <span class="tile-title">illustration <span class="tag">soon</span></span>
-                    <span class="tile-desc">ai-rendered image</span>
-                </span>
-                <span class="kbd">—</span>
-            </button>
+                <button class="wc-tile" id="action-image" data-key="4" disabled>
+                    <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-symbol-color"></i></span>
+                    <span class="wc-tile-body">
+                        <span class="wc-tile-title">Illustration <span class="tag tag-soon">Coming soon</span></span>
+                        <span class="wc-tile-desc">AI-rendered images for your docs</span>
+                    </span>
+                </button>
+            </nav>
+        </section>
 
-            <button class="tile" id="action-history" data-key="5">
-                <span class="tile-num">5</span>
-                <span class="tile-body">
-                    <span class="tile-title">history</span>
-                    <span class="tile-desc">previously generated diagrams</span>
-                </span>
-                <span class="kbd">⌘H</span>
-            </button>
-        </nav>
+        <section aria-labelledby="wc-library-heading">
+            <h2 id="wc-library-heading" class="wc-section-title">Library</h2>
+            <nav class="wc-actions" aria-label="Library">
+                <button class="wc-tile" id="action-history" data-key="5">
+                    <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-history"></i></span>
+                    <span class="wc-tile-body">
+                        <span class="wc-tile-title">Recent diagrams</span>
+                        <span class="wc-tile-desc">Reopen something you made before</span>
+                    </span>
+                    <span class="kbd">⌘H</span>
+                </button>
+            </nav>
+        </section>
 
-        <span class="section-marker">shortcuts</span>
-
-        <ul class="wc-links">
-            <li><a href="#" id="link-settings" class="wc-link">
-                <span class="wc-link-caret">›</span> settings &amp; api keys
-                <span class="kbd">⌘,</span>
-            </a></li>
-            <li><a href="https://flowcraft.app/docs" class="wc-link">
-                <span class="wc-link-caret">›</span> docs
-                <span class="muted">flowcraft.app/docs</span>
-            </a></li>
-            <li><a href="https://github.com/flowcraft/vscode/issues" class="wc-link">
-                <span class="wc-link-caret">›</span> report issue
-                <span class="muted">github</span>
-            </a></li>
-        </ul>
+        <section aria-labelledby="wc-more-heading">
+            <h2 id="wc-more-heading" class="wc-section-title">More</h2>
+            <ul class="wc-links">
+                <li>
+                    <a href="#" id="link-settings" class="wc-link">
+                        <span class="wc-link-icon" aria-hidden="true"><i class="codicon codicon-settings-gear"></i></span>
+                        <span class="wc-link-label">Settings &amp; API keys</span>
+                        <span class="kbd">⌘,</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="https://flowcraft.app/docs" class="wc-link">
+                        <span class="wc-link-icon" aria-hidden="true"><i class="codicon codicon-book"></i></span>
+                        <span class="wc-link-label">Documentation</span>
+                        <span class="wc-link-meta"><i class="codicon codicon-link-external"></i></span>
+                    </a>
+                </li>
+                <li>
+                    <a href="https://github.com/flowcraft/vscode/issues" class="wc-link">
+                        <span class="wc-link-icon" aria-hidden="true"><i class="codicon codicon-comment-discussion"></i></span>
+                        <span class="wc-link-label">Send feedback</span>
+                        <span class="wc-link-meta"><i class="codicon codicon-link-external"></i></span>
+                    </a>
+                </li>
+            </ul>
+        </section>
 
         <footer class="wc-foot">
-            <span class="wc-foot-cell"><span class="dim">STATUS</span> <span id="foot-status" class="ok">ready</span></span>
-            <span class="wc-foot-cell"><span class="dim">MODE</span> <span id="foot-mode">byok</span></span>
-            <span class="wc-foot-cell"><span class="dim">TIP</span> press <kbd>1</kbd>–<kbd>5</kbd> or <kbd>⌘⇧P</kbd> → flowcraft</span>
+            <p class="wc-tip">
+                <span class="wc-tip-label">Tip</span>
+                Press <kbd>1</kbd>–<kbd>5</kbd> to jump to any action, or open the Command Palette with <kbd>⌘⇧P</kbd>.
+            </p>
+            <p class="wc-version">FlowCraft v2.1.0</p>
         </footer>
     </main>
 

--- a/src/webview/welcome/welcome.css
+++ b/src/webview/welcome/welcome.css
@@ -1,139 +1,320 @@
-/* Welcome — terminal-pane layout */
+/* Welcome — refined sidebar, Apple/Airbnb-inspired */
+
+:root {
+  --wc-radius: 10px;
+  --wc-radius-sm: 8px;
+  --wc-font-ui: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", system-ui, sans-serif);
+  --wc-fs-title: 17px;
+  --wc-fs-tile: 13px;
+  --wc-fs-body: 12.5px;
+  --wc-fs-label: 11px;
+  --wc-pad: 16px;
+}
 
 body { padding: 0; overflow-x: hidden; }
 
 .wc {
   display: flex;
   flex-direction: column;
-  gap: var(--fc-sp-6);
-  padding: var(--fc-sp-5);
+  gap: 20px;
+  padding: 18px var(--wc-pad) 14px;
   min-height: 100vh;
+  font-family: var(--wc-font-ui);
+  font-size: var(--wc-fs-body);
+  line-height: 1.5;
+  letter-spacing: 0;
 }
 
-/* Prompt line ——————————————————————————— */
-.wc-head {
+.wc * { font-family: var(--wc-font-ui); }
+.wc .kbd, .wc kbd { font-family: var(--fc-font-mono); }
+
+/* Header ——————————————————————————— */
+.wc-head { padding-top: 4px; }
+.wc-brand {
   display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: var(--fc-sp-4);
-  padding-bottom: var(--fc-sp-4);
-  border-bottom: 1px dashed var(--fc-border);
+  align-items: center;
+  gap: 12px;
 }
-.wc-prompt {
-  font-family: var(--fc-font-mono);
-  font-size: var(--fc-fs-md);
-  color: var(--fc-fg);
-  letter-spacing: 0.01em;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.wc-prompt-user { color: var(--fc-accent); }
-.wc-prompt-sep  { color: var(--fc-fg-dim); }
-.wc-prompt-host { color: var(--fc-fg-muted); }
-.wc-prompt-path { color: var(--fc-fg-muted); margin-left: var(--fc-sp-3); }
-.wc-prompt-caret {
+.wc-mark {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--wc-radius-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--fc-accent) 14%, transparent);
   color: var(--fc-accent);
-  margin-left: var(--fc-sp-3);
-  animation: wc-blink 1.1s steps(1) infinite;
+  flex-shrink: 0;
 }
-@keyframes wc-blink { 50% { opacity: 0; } }
-
-.wc-version {
-  font-size: var(--fc-fs-sm);
-  font-family: var(--fc-font-mono);
+.wc-mark-glyph { font-size: 18px; line-height: 1; }
+.wc-brand-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.wc-title {
+  font-size: var(--wc-fs-title);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--fc-fg);
+  text-transform: none;
+  line-height: 1.2;
+}
+.wc-subtitle {
+  font-size: var(--wc-fs-body);
+  color: var(--fc-fg-muted);
+  line-height: 1.35;
 }
 
-/* Status block ——————————————————————————— */
-.wc-status {
-  display: flex;
-  flex-direction: column;
-  gap: var(--fc-sp-3);
-  padding: var(--fc-sp-4) var(--fc-sp-5);
+/* Plan card ——————————————————————————— */
+.wc-card {
   background: var(--fc-surface);
   border: 1px solid var(--fc-border);
-  border-radius: var(--fc-radius-1);
+  border-radius: var(--wc-radius);
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
-.wc-status-row {
+.wc-plan-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--fc-sp-4);
+  gap: 8px;
 }
-.wc-status-label {
-  font-family: var(--fc-font-mono);
-  font-size: var(--fc-fs-sm);
+.wc-plan-heading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.wc-eyebrow {
+  font-size: var(--wc-fs-label);
+  font-weight: 600;
+  color: var(--fc-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.wc .tag {
+  font-family: var(--wc-font-ui);
+  font-size: var(--wc-fs-label);
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: 0;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--fc-bg-alt);
+}
+.wc .tag .dot { width: 6px; height: 6px; }
+
+.wc-upgrade {
+  font-size: var(--wc-fs-body);
+  font-weight: 600;
+  color: var(--fc-accent);
+  border-bottom: none;
+}
+.wc-upgrade:hover { text-decoration: underline; border-bottom: none; }
+
+.wc-card .progress {
+  height: 6px;
+  border-radius: 999px;
+  border: none;
+  background: color-mix(in srgb, var(--fc-fg) 10%, transparent);
+}
+.wc-card .progress > .fill { border-radius: 999px; }
+
+.wc-plan-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: var(--wc-fs-body);
+}
+.wc-usage-text { color: var(--fc-fg); font-weight: 500; }
+.wc-usage-limit { color: var(--fc-fg-muted); }
+
+/* Sections ——————————————————————————— */
+.wc-section-title {
+  font-size: var(--wc-fs-label);
+  font-weight: 600;
   color: var(--fc-fg-muted);
   text-transform: uppercase;
   letter-spacing: 0.08em;
+  margin-bottom: 8px;
+  padding: 0 2px;
 }
-.wc-status-foot { font-size: var(--fc-fs-sm); }
 
 /* Actions ——————————————————————————— */
 .wc-actions {
   display: flex;
   flex-direction: column;
-  gap: var(--fc-sp-3);
+  gap: 6px;
 }
 
-/* Links list ——————————————————————————— */
+.wc-tile {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 12px 12px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--wc-radius-sm);
+  cursor: pointer;
+  color: var(--fc-fg);
+  text-align: left;
+  font-family: var(--wc-font-ui);
+  transition: background var(--fc-t-fast), border-color var(--fc-t-fast), transform var(--fc-t-fast);
+}
+.wc-tile:hover:not(:disabled) {
+  background: var(--fc-surface);
+  border-color: var(--fc-border);
+}
+.wc-tile:active:not(:disabled) { transform: scale(0.99); }
+.wc-tile:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+.wc-tile:focus-visible {
+  outline: 2px solid var(--fc-border-hi);
+  outline-offset: 1px;
+}
+
+.wc-tile-icon {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--fc-bg-alt);
+  color: var(--fc-fg);
+  border-radius: var(--wc-radius-sm);
+  flex-shrink: 0;
+}
+.wc-tile-icon i { font-size: 16px; }
+.wc-tile:hover:not(:disabled) .wc-tile-icon {
+  background: color-mix(in srgb, var(--fc-accent) 14%, transparent);
+  color: var(--fc-accent);
+}
+
+.wc-tile-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.wc-tile-title {
+  font-size: var(--wc-fs-tile);
+  font-weight: 600;
+  color: var(--fc-fg);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.wc-tile-desc {
+  font-size: var(--wc-fs-body);
+  color: var(--fc-fg-muted);
+  line-height: 1.35;
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.wc .kbd {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 5px;
+  border: 1px solid var(--fc-border);
+  background: var(--fc-bg-alt);
+  color: var(--fc-fg-muted);
+  font-weight: 500;
+}
+
+.tag-soon {
+  color: var(--fc-fg-muted);
+  background: var(--fc-bg-alt);
+}
+
+/* Links ——————————————————————————— */
 .wc-links {
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: var(--fc-sp-1);
+  gap: 2px;
 }
 .wc-link {
   display: flex;
   align-items: center;
-  gap: var(--fc-sp-3);
-  padding: var(--fc-sp-2) var(--fc-sp-3);
-  font-family: var(--fc-font-mono);
-  font-size: var(--fc-fs);
+  gap: 12px;
+  padding: 10px 12px;
+  font-size: var(--wc-fs-tile);
   color: var(--fc-fg);
+  border-radius: var(--wc-radius-sm);
   border: 1px solid transparent;
-  border-radius: var(--fc-radius-1);
+  border-bottom: 1px solid transparent;
 }
 .wc-link:hover {
   background: var(--fc-surface);
   border-color: var(--fc-border);
-  border-bottom-color: var(--fc-border); /* override anchor dashed underline */
+  border-bottom-color: var(--fc-border);
 }
-.wc-link-caret { color: var(--fc-fg-dim); }
-.wc-link .kbd, .wc-link .muted { margin-left: auto; }
+.wc-link-icon {
+  width: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fc-fg-muted);
+}
+.wc-link-icon i { font-size: 15px; }
+.wc-link-label { flex: 1; font-weight: 500; }
+.wc-link-meta { color: var(--fc-fg-dim); font-size: 11px; }
+.wc-link-meta i { font-size: 12px; }
+.wc-link .kbd { margin-left: auto; }
 
-/* Status line (terminal footer) ——————————————————— */
+/* Footer ——————————————————————————— */
 .wc-foot {
   margin-top: auto;
+  padding-top: 14px;
+  border-top: 1px solid var(--fc-border);
   display: flex;
-  flex-wrap: wrap;
-  gap: var(--fc-sp-5);
-  padding: var(--fc-sp-3) var(--fc-sp-4);
-  font-family: var(--fc-font-mono);
-  font-size: 10px;
-  color: var(--fc-fg-muted);
-  background: var(--fc-surface);
-  border: 1px solid var(--fc-border);
-  border-radius: var(--fc-radius-1);
-  letter-spacing: 0.04em;
+  flex-direction: column;
+  gap: 6px;
 }
-.wc-foot .dim { color: var(--fc-fg-dim); margin-right: 4px; }
-.wc-foot-cell { display: inline-flex; align-items: center; gap: 4px; }
-.wc-foot kbd { font-size: 9px; padding: 0 4px; }
+.wc-tip {
+  font-size: var(--wc-fs-body);
+  color: var(--fc-fg-muted);
+  line-height: 1.5;
+}
+.wc-tip-label {
+  font-weight: 600;
+  color: var(--fc-fg);
+  margin-right: 4px;
+}
+.wc-tip kbd {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 4px;
+  border: 1px solid var(--fc-border);
+  background: var(--fc-bg-alt);
+  color: var(--fc-fg-muted);
+  margin: 0 1px;
+}
+.wc-version {
+  font-size: var(--wc-fs-label);
+  color: var(--fc-fg-dim);
+  letter-spacing: 0.02em;
+}
 
-/* Entrance — one subtle, staggered reveal */
-.wc-head     { animation: wc-in 220ms ease-out both; }
-.wc-status   { animation: wc-in 220ms ease-out 40ms  both; }
-.wc-actions  { animation: wc-in 220ms ease-out 80ms  both; }
-.wc-links    { animation: wc-in 220ms ease-out 120ms both; }
-.wc-foot     { animation: wc-in 220ms ease-out 160ms both; }
+/* Entrance animation ——————————————————————————— */
+.wc-head     { animation: wc-in 260ms ease-out both; }
+.wc-card     { animation: wc-in 260ms ease-out 60ms  both; }
+.wc > section:nth-of-type(2) { animation: wc-in 260ms ease-out 110ms both; }
+.wc > section:nth-of-type(3) { animation: wc-in 260ms ease-out 160ms both; }
+.wc > section:nth-of-type(4) { animation: wc-in 260ms ease-out 210ms both; }
+.wc-foot     { animation: wc-in 260ms ease-out 260ms both; }
 
 @keyframes wc-in {
-  from { opacity: 0; transform: translateY(3px); }
+  from { opacity: 0; transform: translateY(4px); }
   to   { opacity: 1; transform: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .wc-head, .wc-status, .wc-actions, .wc-links, .wc-foot { animation: none; }
-  .wc-prompt-caret { animation: none; opacity: 1; }
+  .wc-head, .wc-card, .wc > section, .wc-foot { animation: none; }
 }

--- a/src/webview/welcome/welcome.js
+++ b/src/webview/welcome/welcome.js
@@ -58,26 +58,29 @@ function wireLinks() {
 function renderUsage(usage) {
   if (!usage) return;
 
-  const progress  = getById('usage-progress');
-  const fill      = getById('usage-fill');
-  const text      = getById('usage-text');
-  const limit     = getById('usage-limit');
-  const badge     = getById('subscription-badge');
-  const footMode  = getById('foot-mode');
+  const progress = getById('usage-progress');
+  const fill     = getById('usage-fill');
+  const text     = getById('usage-text');
+  const limit    = getById('usage-limit');
+  const badge    = getById('subscription-badge');
+  const upgrade  = getById('link-upgrade');
 
   if (usage.subscribed) {
     badge.className = 'tag tag-pro';
-    badge.innerHTML = '<span class="dot"></span>pro';
+    badge.innerHTML = '<span class="dot"></span>Pro';
     if (progress) progress.classList.add('hidden');
-    text.textContent  = `${usage.diagramsCreated} diagrams generated`;
-    limit.textContent = '∞';
-    if (footMode) footMode.textContent = 'pro';
+    if (upgrade)  upgrade.classList.add('hidden');
+    text.textContent  = `${usage.diagramsCreated} diagrams created`;
+    limit.textContent = 'Unlimited';
   } else {
     badge.className = 'tag';
-    badge.innerHTML = '<span class="dot"></span>free';
+    badge.innerHTML = '<span class="dot"></span>Free';
     if (progress) progress.classList.remove('hidden');
+    if (upgrade)  upgrade.classList.remove('hidden');
 
-    const pct = Math.min(100, (usage.diagramsCreated / usage.freeLimit) * 100);
+    const used = usage.diagramsCreated;
+    const total = usage.freeLimit;
+    const pct = Math.min(100, (used / total) * 100);
     if (fill) {
       fill.style.width = `${pct}%`;
       fill.classList.remove('warn', 'err');
@@ -85,8 +88,8 @@ function renderUsage(usage) {
       else if (pct >= 70) fill.classList.add('warn');
     }
 
-    text.textContent  = `[${usage.diagramsCreated}/${usage.freeLimit}] diagrams`;
-    limit.textContent = `${Math.max(0, usage.freeLimit - usage.diagramsCreated)} left`;
-    if (footMode) footMode.textContent = 'byok';
+    const remaining = Math.max(0, total - used);
+    text.textContent  = `${used} of ${total} diagrams used`;
+    limit.textContent = remaining === 1 ? '1 left' : `${remaining} left`;
   }
 }


### PR DESCRIPTION
## Summary
- Adds a per-provider model picker in Settings. `providerModels` is persisted in settings and passed to the FlowCraft API via the new `model` field.
- Refreshes `PROVIDER_INFO` model lists with current ids (GPT-4o family, Claude 4 family + 3.x, Gemini 2.5) and exposes `getSupportedModels` / `getDefaultModel` helpers.
- Visual refresh of Settings and Welcome webviews (HTML/CSS/JS, both `media/` and `src/`).
- Adds `CLAUDE.md` and `scripts/deploy.sh` for repo tooling.

## Test plan
- [ ] Select a model per provider in Settings — value persists across reloads
- [ ] Generate a Mermaid diagram — request includes chosen `model`
- [ ] Generate an infographic / illustration — chosen `model` is sent
- [ ] Clearing model reverts to server default (no `model` field)
- [ ] Welcome + Settings webviews render correctly in both dark/light themes