### PR TITLE
feat: welcome/settings parity + persist raw-fetch diagrams to history

### DIFF
--- a/media/webview/settings/index.html
+++ b/media/webview/settings/index.html
@@ -95,6 +95,11 @@
             </div>
 
             <p class="st-footnote"><i class="codicon codicon-shield"></i> Keys are stored securely in VS Code's secret storage — never synced or shared.</p>
+            <p class="st-footnote">
+                <button class="btn btn-sm" id="reset-keys-btn" title="Clear stored API keys">
+                    <i class="codicon codicon-key"></i> Reset API keys…
+                </button>
+            </p>
         </section>
 
         <!-- ————— Defaults ————— -->

--- a/media/webview/settings/settings.js
+++ b/media/webview/settings/settings.js
@@ -82,6 +82,11 @@ function wire() {
     if (confirm('Reset all settings to their defaults? Your API keys will be kept.')) postMessage('resetSettings');
   });
 
+  // Reset API keys — delegates to the flowcraft.resetApiKey command
+  getById('reset-keys-btn')?.addEventListener('click', () => {
+    postMessage('resetApiKeys');
+  });
+
   // Reveal / hide passwords
   getById('reveal-btn')?.addEventListener('click', () => {
     keysRevealed = !keysRevealed;

--- a/media/webview/welcome/index.html
+++ b/media/webview/welcome/index.html
@@ -65,18 +65,26 @@
                     <span class="kbd">⌘⇧G</span>
                 </button>
 
-                <button class="wc-tile" id="action-infographic" data-key="3" disabled>
-                    <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-graph"></i></span>
+                <button class="wc-tile" id="action-file" data-key="3">
+                    <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-file-code"></i></span>
                     <span class="wc-tile-body">
-                        <span class="wc-tile-title">Infographic <span class="tag tag-soon">Coming soon</span></span>
-                        <span class="wc-tile-desc">Visual summaries from data or notes</span>
+                        <span class="wc-tile-title">From current file</span>
+                        <span class="wc-tile-desc">Flowchart of the active editor file (≤10k chars)</span>
                     </span>
                 </button>
 
-                <button class="wc-tile" id="action-image" data-key="4" disabled>
+                <button class="wc-tile" id="action-infographic" data-key="4">
+                    <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-graph"></i></span>
+                    <span class="wc-tile-body">
+                        <span class="wc-tile-title">Infographic</span>
+                        <span class="wc-tile-desc">SVG visual summaries from a prompt</span>
+                    </span>
+                </button>
+
+                <button class="wc-tile" id="action-image" data-key="5">
                     <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-symbol-color"></i></span>
                     <span class="wc-tile-body">
-                        <span class="wc-tile-title">Illustration <span class="tag tag-soon">Coming soon</span></span>
+                        <span class="wc-tile-title">Illustration</span>
                         <span class="wc-tile-desc">AI-rendered images for your docs</span>
                     </span>
                 </button>
@@ -86,7 +94,7 @@
         <section aria-labelledby="wc-library-heading">
             <h2 id="wc-library-heading" class="wc-section-title">Library</h2>
             <nav class="wc-actions" aria-label="Library">
-                <button class="wc-tile" id="action-history" data-key="5">
+                <button class="wc-tile" id="action-history" data-key="6">
                     <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-history"></i></span>
                     <span class="wc-tile-body">
                         <span class="wc-tile-title">Recent diagrams</span>
@@ -105,6 +113,18 @@
                         <span class="wc-link-icon" aria-hidden="true"><i class="codicon codicon-settings-gear"></i></span>
                         <span class="wc-link-label">Settings &amp; API keys</span>
                         <span class="kbd">⌘,</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="#" id="link-sync-usage" class="wc-link">
+                        <span class="wc-link-icon" aria-hidden="true"><i class="codicon codicon-sync"></i></span>
+                        <span class="wc-link-label">Sync usage stats</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="#" id="link-reset-keys" class="wc-link">
+                        <span class="wc-link-icon" aria-hidden="true"><i class="codicon codicon-key"></i></span>
+                        <span class="wc-link-label">Reset API keys</span>
                     </a>
                 </li>
                 <li>
@@ -127,9 +147,9 @@
         <footer class="wc-foot">
             <p class="wc-tip">
                 <span class="wc-tip-label">Tip</span>
-                Press <kbd>1</kbd>–<kbd>5</kbd> to jump to any action, or open the Command Palette with <kbd>⌘⇧P</kbd>.
+                Press <kbd>1</kbd>–<kbd>6</kbd> to jump to any action, or open the Command Palette with <kbd>⌘⇧P</kbd>.
             </p>
-            <p class="wc-version">FlowCraft v2.1.0</p>
+            <p class="wc-version">FlowCraft v2.2.0</p>
         </footer>
     </main>
 

--- a/media/webview/welcome/welcome.js
+++ b/media/webview/welcome/welcome.js
@@ -4,6 +4,7 @@ import { getById } from '../shared/utils/dom.js';
 const ACTIONS = [
   { id: 'action-diagram',     command: 'generateDiagram' },
   { id: 'action-selection',   command: 'generateFromSelection' },
+  { id: 'action-file',        command: 'generateFromFile' },
   { id: 'action-infographic', command: 'createInfographic' },
   { id: 'action-image',       command: 'generateImage' },
   { id: 'action-history',     command: 'viewHistory' },
@@ -51,6 +52,20 @@ function wireLinks() {
     settings.addEventListener('click', (e) => {
       e.preventDefault();
       postMessage('openSettings');
+    });
+  }
+  const resetKeys = getById('link-reset-keys');
+  if (resetKeys) {
+    resetKeys.addEventListener('click', (e) => {
+      e.preventDefault();
+      postMessage('resetApiKeys');
+    });
+  }
+  const syncUsage = getById('link-sync-usage');
+  if (syncUsage) {
+    syncUsage.addEventListener('click', (e) => {
+      e.preventDefault();
+      postMessage('syncUsage');
     });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flowcraft",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flowcraft",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "dependencies": {
         "@types/vscode": "^1.95.0",
         "@vscode/webview-ui-toolkit": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/shagunmistry/FlowCraft-VsCode-Extension.git"
   },
   "icon": "FlowCraftLogo_New.png",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/shagunmistry/FlowCraft-VsCode-Extension.git"
   },
   "icon": "FlowCraftLogo_New.png",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "engines": {
     "vscode": "^1.85.0"
   },
@@ -106,39 +106,9 @@
         "icon": "$(file-code)"
       },
       {
-        "command": "flowcraft.viewDiagram",
-        "title": "FlowCraft: View Diagram",
-        "icon": "$(eye)"
-      },
-      {
-        "command": "flowcraft.exportDiagram",
-        "title": "FlowCraft: Export Diagram",
-        "icon": "$(export)"
-      },
-      {
-        "command": "flowcraft.deleteDiagram",
-        "title": "FlowCraft: Delete Diagram",
-        "icon": "$(trash)"
-      },
-      {
-        "command": "flowcraft.regenerateDiagram",
-        "title": "FlowCraft: Regenerate Diagram",
-        "icon": "$(refresh)"
-      },
-      {
-        "command": "flowcraft.duplicateDiagram",
-        "title": "FlowCraft: Duplicate Diagram",
-        "icon": "$(copy)"
-      },
-      {
         "command": "flowcraft.syncUsage",
         "title": "FlowCraft: Sync Usage Stats",
         "icon": "$(sync)"
-      },
-      {
-        "command": "flowcraft.refreshHistory",
-        "title": "FlowCraft: Refresh History",
-        "icon": "$(refresh)"
       },
       {
         "command": "flowcraft.generateFlowDiagram",
@@ -190,28 +160,6 @@
         {
           "command": "flowcraft.generateFromFile",
           "group": "flowcraft@1"
-        }
-      ],
-      "commandPalette": [
-        {
-          "command": "flowcraft.viewDiagram",
-          "when": "false"
-        },
-        {
-          "command": "flowcraft.exportDiagram",
-          "when": "false"
-        },
-        {
-          "command": "flowcraft.deleteDiagram",
-          "when": "false"
-        },
-        {
-          "command": "flowcraft.regenerateDiagram",
-          "when": "false"
-        },
-        {
-          "command": "flowcraft.duplicateDiagram",
-          "when": "false"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import { FlowCraftClient } from "./api/flowcraft-client";
 import { WelcomeViewProvider } from "./views/welcome-view";
 import { SettingsViewProvider } from "./views/settings-view";
 import { initLogger } from "./utils/logger";
-import { Provider } from "./types";
+import { Diagram, DiagramCategory, DiagramType, Provider } from "./types";
 
 const FLOWCRAFT_API_URL = "https://flowcraft-api-cb66lpneaq-ue.a.run.app";
 const OPENAI_KEY_SECRET = "flowcraft.openai.key";
@@ -48,6 +48,36 @@ async function getProviderApiKey(
   provider: Provider
 ): Promise<string | undefined> {
   return await apiKeyService.retrieve(provider);
+}
+
+function persistRawFetchDiagram(
+  stateManager: StateManager,
+  params: {
+    id: string;
+    title: string;
+    description: string;
+    type: DiagramType;
+    mermaidCode: string;
+  }
+): void {
+  try {
+    const now = new Date();
+    const diagram: Diagram = {
+      id: params.id,
+      title: params.title,
+      description: params.description,
+      type: params.type,
+      category: DiagramCategory.Mermaid,
+      content: params.mermaidCode ?? "",
+      isPublic: false,
+      createdAt: now,
+      updatedAt: now,
+      tokensUsed: 0,
+    };
+    stateManager.addDiagram(diagram);
+  } catch (err) {
+    console.error("Failed to persist diagram to history:", err);
+  }
 }
 
 async function promptForProviderApiKey(
@@ -212,10 +242,41 @@ export async function activate(context: vscode.ExtensionContext) {
   let resetKeyCommand = vscode.commands.registerCommand(
     "flowcraft.resetApiKey",
     async () => {
+      type ResetItem = vscode.QuickPickItem & { value: "all" | Provider };
+      const items: ResetItem[] = [
+        { label: "$(trash) All providers", description: "clear every stored key", value: "all" },
+        { label: "OpenAI",    value: Provider.OpenAI },
+        { label: "Anthropic", value: Provider.Anthropic },
+        { label: "Google",    value: Provider.Google },
+        { label: "FlowCraft", value: Provider.FlowCraft },
+      ];
+      const picked = await vscode.window.showQuickPick(items, {
+        title: "FlowCraft · reset API key",
+        placeHolder: "Which provider key would you like to clear?",
+      });
+      if (!picked) return;
+
+      // Also scrub the legacy single-provider secret if it still exists.
       await context.secrets.delete(OPENAI_KEY_SECRET);
-      vscode.window.showInformationMessage(
-        "API key has been reset. You will be prompted for a new key on next use."
-      );
+
+      if (picked.value === "all") {
+        await apiKeyService.clearAll();
+        vscode.window.showInformationMessage(
+          "All FlowCraft provider keys have been cleared. You will be prompted on next use."
+        );
+      } else {
+        await apiKeyService.delete(picked.value);
+        vscode.window.showInformationMessage(
+          `${picked.value} API key has been cleared. You will be prompted on next use.`
+        );
+      }
+    }
+  );
+
+  let openWelcomeCommand = vscode.commands.registerCommand(
+    "flowcraft.openWelcome",
+    async () => {
+      await vscode.commands.executeCommand("flowcraft.welcomeView.focus");
     }
   );
 
@@ -227,15 +288,134 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   );
 
+  let syncUsageCommand = vscode.commands.registerCommand(
+    "flowcraft.syncUsage",
+    async () => {
+      try {
+        const usage = await usageService.syncFromAPI();
+        const label = usage.subscribed
+          ? `Pro · ${usage.diagramsCreated} diagram${usage.diagramsCreated === 1 ? "" : "s"} created`
+          : `${usage.diagramsCreated} of ${usage.freeLimit} used · ${Math.max(0, usage.freeLimit - usage.diagramsCreated)} left`;
+        vscode.window.showInformationMessage(`FlowCraft usage · ${label}`);
+      } catch (error: any) {
+        const msg = error?.message ?? String(error);
+        if (msg.toLowerCase().includes("no api key")) {
+          showApiKeyError(stateManager.getSetting("defaultProvider"));
+        } else {
+          vscode.window.showErrorMessage(`Couldn't sync usage · ${msg}`);
+        }
+      }
+    }
+  );
+
+  async function runVisualGeneration(
+    kind: "infographic" | "illustration"
+  ): Promise<void> {
+    const prompt = await vscode.window.showInputBox({
+      title: `FlowCraft · ${kind}`,
+      prompt: `Describe the ${kind} you want FlowCraft to produce`,
+      placeHolder: kind === "infographic"
+        ? "e.g. A 4-step infographic explaining OAuth 2.0"
+        : "e.g. An isometric illustration of a cloud deployment pipeline",
+      ignoreFocusOut: true,
+      validateInput: (value: string) => {
+        if (!value || value.trim().length === 0) return "Please provide a description";
+        if (value.length > 10000) return "Description is too long (max 10,000 characters)";
+        return null;
+      },
+    });
+    if (!prompt) return;
+
+    const palettePick = await vscode.window.showQuickPick(
+      [
+        { label: "Brand colors", value: "brand colors" },
+        { label: "Monochromatic", value: "monochromatic" },
+        { label: "Complementary", value: "complementary" },
+        { label: "Analogous", value: "analogous" },
+      ],
+      {
+        title: `FlowCraft · ${kind} · palette`,
+        placeHolder: "Pick a color palette",
+      }
+    );
+    if (!palettePick) return;
+
+    const complexityPick = await vscode.window.showQuickPick(
+      [
+        { label: "Simple",  value: "simple"  as const },
+        { label: "Medium",  value: "medium"  as const },
+        { label: "Detailed",value: "complex" as const },
+      ],
+      {
+        title: `FlowCraft · ${kind} · detail`,
+        placeHolder: "How much detail?",
+      }
+    );
+    if (!complexityPick) return;
+
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: `flowcraft › ${kind}`,
+        cancellable: false,
+      },
+      async (progress) => {
+        progress.report({ message: "checking credentials…", increment: 10 });
+        const apiKey = await ensureProviderApiKey(stateManager, apiKeyService);
+        if (!apiKey) {
+          showApiKeyError(stateManager.getSetting("defaultProvider"));
+          return;
+        }
+
+        progress.report({ message: "sending prompt to model…", increment: 40 });
+
+        try {
+          const result = await diagramService.generate({
+            prompt,
+            type: kind === "infographic" ? DiagramType.Infographic : DiagramType.Illustration,
+            colorPalette: palettePick.value,
+            complexityLevel: complexityPick.value,
+            isPublic: stateManager.getSetting("defaultPrivacy") !== "private",
+          });
+
+          progress.report({ message: "rendering…", increment: 40 });
+
+          if (result?.id) {
+            progress.report({ message: "done", increment: 10 });
+            openDiagramResult(result.id);
+          } else {
+            vscode.window.showErrorMessage(
+              `FlowCraft didn't return a ${kind}. Try again or tweak your prompt.`
+            );
+          }
+        } catch (error: any) {
+          const friendly = humanizeError(error?.message ?? String(error));
+          vscode.window
+            .showErrorMessage(
+              friendly.detail ? `${friendly.title} · ${friendly.detail}` : friendly.title,
+              "Retry",
+              "Open Settings"
+            )
+            .then((choice) => {
+              if (choice === "Retry") {
+                vscode.commands.executeCommand("flowcraft.openGenerationView", kind);
+              } else if (choice === "Open Settings") {
+                vscode.commands.executeCommand("flowcraft.openSettings");
+              }
+            });
+          console.error(`Error generating ${kind}:`, error);
+        }
+      }
+    );
+  }
+
   let openGenerationViewCommand = vscode.commands.registerCommand(
     "flowcraft.openGenerationView",
     async (type?: string) => {
       if (type === "infographic") {
-        vscode.window.showInformationMessage(
-          "Infographic generation coming soon!"
-        );
-      } else if (type === "image") {
-        vscode.window.showInformationMessage("Image generation coming soon!");
+        await runVisualGeneration("infographic");
+      } else if (type === "image" || type === "illustration") {
+        await runVisualGeneration("illustration");
       } else {
         type DiagramItem = vscode.QuickPickItem & { value?: string };
         const diagramItems: DiagramItem[] = [
@@ -631,7 +811,17 @@ export async function activate(context: vscode.ExtensionContext) {
                   inserted_diagram.data.length > 0
                 ) {
                   progress.report({ increment: 100 });
-                  const diagramUrl = `https://flowcraft.app/vscode/${inserted_diagram.data[0].id}`;
+                  const diagramId = inserted_diagram.data[0].id;
+
+                  persistRawFetchDiagram(stateManager, {
+                    id: diagramId,
+                    title: title ?? "Untitled diagram",
+                    description: fileContent,
+                    type: DiagramType.Flowchart,
+                    mermaidCode: diagram,
+                  });
+
+                  const diagramUrl = `https://flowcraft.app/vscode/${diagramId}`;
 
                   vscode.env.openExternal(vscode.Uri.parse(diagramUrl));
 
@@ -744,7 +934,17 @@ export async function activate(context: vscode.ExtensionContext) {
                   inserted_diagram.data.length > 0
                 ) {
                   progress.report({ increment: 100 });
-                  const diagramUrl = `https://flowcraft.app/vscode/${inserted_diagram.data[0].id}`;
+                  const diagramId = inserted_diagram.data[0].id;
+
+                  persistRawFetchDiagram(stateManager, {
+                    id: diagramId,
+                    title: title ?? "Untitled diagram",
+                    description: selection,
+                    type: DiagramType.Flowchart,
+                    mermaidCode: diagram,
+                  });
+
+                  const diagramUrl = `https://flowcraft.app/vscode/${diagramId}`;
 
                   vscode.env.openExternal(vscode.Uri.parse(diagramUrl));
                   vscode.window
@@ -841,7 +1041,17 @@ export async function activate(context: vscode.ExtensionContext) {
                   inserted_diagram.data.length > 0
                 ) {
                   progress.report({ increment: 100 });
-                  const diagramUrl = `https://flowcraft.app/vscode/${inserted_diagram.data[0].id}`;
+                  const diagramId = inserted_diagram.data[0].id;
+
+                  persistRawFetchDiagram(stateManager, {
+                    id: diagramId,
+                    title: title ?? "Untitled diagram",
+                    description: fileContext,
+                    type: DiagramType.Class,
+                    mermaidCode: diagram,
+                  });
+
+                  const diagramUrl = `https://flowcraft.app/vscode/${diagramId}`;
 
                   vscode.env.openExternal(vscode.Uri.parse(diagramUrl));
 
@@ -939,7 +1149,17 @@ export async function activate(context: vscode.ExtensionContext) {
                   inserted_diagram.data.length > 0
                 ) {
                   progress.report({ increment: 100 });
-                  const diagramUrl = `https://flowcraft.app/vscode/${inserted_diagram.data[0].id}`;
+                  const diagramId = inserted_diagram.data[0].id;
+
+                  persistRawFetchDiagram(stateManager, {
+                    id: diagramId,
+                    title: title ?? "Untitled diagram",
+                    description: selection,
+                    type: DiagramType.Class,
+                    mermaidCode: diagram,
+                  });
+
+                  const diagramUrl = `https://flowcraft.app/vscode/${diagramId}`;
 
                   vscode.env.openExternal(vscode.Uri.parse(diagramUrl));
 
@@ -981,7 +1201,9 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(generateClassDiagramDisposable);
   context.subscriptions.push(generateSelectionClassDiagramDisposable);
   context.subscriptions.push(resetKeyCommand);
+  context.subscriptions.push(openWelcomeCommand);
   context.subscriptions.push(openSettingsCommand);
+  context.subscriptions.push(syncUsageCommand);
   context.subscriptions.push(openGenerationViewCommand);
   context.subscriptions.push(showHistoryCommand);
   context.subscriptions.push(generateFromSelectionCommand);

--- a/src/views/settings-view.ts
+++ b/src/views/settings-view.ts
@@ -37,7 +37,8 @@ export class SettingsViewProvider implements vscode.WebviewViewProvider {
       loadSettings: async () => this.sendSettingsData(),
       saveSettings: async (data: any) => this.saveSettings(data),
       testConnection: async (data: { provider: string, apiKey: string }) => this.testConnection(data),
-      resetSettings: async () => this.resetSettings()
+      resetSettings: async () => this.resetSettings(),
+      resetApiKeys: async () => { await vscode.commands.executeCommand('flowcraft.resetApiKey'); }
     });
 
     // Update on state changes

--- a/src/views/welcome-view.ts
+++ b/src/views/welcome-view.ts
@@ -35,10 +35,13 @@ export class WelcomeViewProvider implements vscode.WebviewViewProvider {
     setupMessageListener(webviewView.webview, {
       generateDiagram: async () => { await vscode.commands.executeCommand('flowcraft.openGenerationView'); },
       generateFromSelection: async () => { await vscode.commands.executeCommand('flowcraft.generateFromSelection'); },
+      generateFromFile: async () => { await vscode.commands.executeCommand('flowcraft.generateFromFile'); },
       createInfographic: async () => { await vscode.commands.executeCommand('flowcraft.openGenerationView', 'infographic'); },
-      generateImage: async () => { await vscode.commands.executeCommand('flowcraft.openGenerationView', 'image'); },
+      generateImage: async () => { await vscode.commands.executeCommand('flowcraft.openGenerationView', 'illustration'); },
       viewHistory: async () => { await vscode.commands.executeCommand('flowcraft.showHistory'); },
       openSettings: async () => { await vscode.commands.executeCommand('flowcraft.openSettings'); },
+      resetApiKeys: async () => { await vscode.commands.executeCommand('flowcraft.resetApiKey'); },
+      syncUsage: async () => { await vscode.commands.executeCommand('flowcraft.syncUsage'); },
       checkUsage: async () => this.sendUsageData()
     });
 

--- a/src/webview/settings/index.html
+++ b/src/webview/settings/index.html
@@ -95,6 +95,11 @@
             </div>
 
             <p class="st-footnote"><i class="codicon codicon-shield"></i> Keys are stored securely in VS Code's secret storage — never synced or shared.</p>
+            <p class="st-footnote">
+                <button class="btn btn-sm" id="reset-keys-btn" title="Clear stored API keys">
+                    <i class="codicon codicon-key"></i> Reset API keys…
+                </button>
+            </p>
         </section>
 
         <!-- ————— Defaults ————— -->

--- a/src/webview/settings/settings.js
+++ b/src/webview/settings/settings.js
@@ -82,6 +82,11 @@ function wire() {
     if (confirm('Reset all settings to their defaults? Your API keys will be kept.')) postMessage('resetSettings');
   });
 
+  // Reset API keys — delegates to the flowcraft.resetApiKey command
+  getById('reset-keys-btn')?.addEventListener('click', () => {
+    postMessage('resetApiKeys');
+  });
+
   // Reveal / hide passwords
   getById('reveal-btn')?.addEventListener('click', () => {
     keysRevealed = !keysRevealed;

--- a/src/webview/welcome/index.html
+++ b/src/webview/welcome/index.html
@@ -65,18 +65,26 @@
                     <span class="kbd">⌘⇧G</span>
                 </button>
 
-                <button class="wc-tile" id="action-infographic" data-key="3" disabled>
-                    <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-graph"></i></span>
+                <button class="wc-tile" id="action-file" data-key="3">
+                    <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-file-code"></i></span>
                     <span class="wc-tile-body">
-                        <span class="wc-tile-title">Infographic <span class="tag tag-soon">Coming soon</span></span>
-                        <span class="wc-tile-desc">Visual summaries from data or notes</span>
+                        <span class="wc-tile-title">From current file</span>
+                        <span class="wc-tile-desc">Flowchart of the active editor file (≤10k chars)</span>
                     </span>
                 </button>
 
-                <button class="wc-tile" id="action-image" data-key="4" disabled>
+                <button class="wc-tile" id="action-infographic" data-key="4">
+                    <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-graph"></i></span>
+                    <span class="wc-tile-body">
+                        <span class="wc-tile-title">Infographic</span>
+                        <span class="wc-tile-desc">SVG visual summaries from a prompt</span>
+                    </span>
+                </button>
+
+                <button class="wc-tile" id="action-image" data-key="5">
                     <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-symbol-color"></i></span>
                     <span class="wc-tile-body">
-                        <span class="wc-tile-title">Illustration <span class="tag tag-soon">Coming soon</span></span>
+                        <span class="wc-tile-title">Illustration</span>
                         <span class="wc-tile-desc">AI-rendered images for your docs</span>
                     </span>
                 </button>
@@ -86,7 +94,7 @@
         <section aria-labelledby="wc-library-heading">
             <h2 id="wc-library-heading" class="wc-section-title">Library</h2>
             <nav class="wc-actions" aria-label="Library">
-                <button class="wc-tile" id="action-history" data-key="5">
+                <button class="wc-tile" id="action-history" data-key="6">
                     <span class="wc-tile-icon" aria-hidden="true"><i class="codicon codicon-history"></i></span>
                     <span class="wc-tile-body">
                         <span class="wc-tile-title">Recent diagrams</span>
@@ -105,6 +113,18 @@
                         <span class="wc-link-icon" aria-hidden="true"><i class="codicon codicon-settings-gear"></i></span>
                         <span class="wc-link-label">Settings &amp; API keys</span>
                         <span class="kbd">⌘,</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="#" id="link-sync-usage" class="wc-link">
+                        <span class="wc-link-icon" aria-hidden="true"><i class="codicon codicon-sync"></i></span>
+                        <span class="wc-link-label">Sync usage stats</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="#" id="link-reset-keys" class="wc-link">
+                        <span class="wc-link-icon" aria-hidden="true"><i class="codicon codicon-key"></i></span>
+                        <span class="wc-link-label">Reset API keys</span>
                     </a>
                 </li>
                 <li>
@@ -127,9 +147,9 @@
         <footer class="wc-foot">
             <p class="wc-tip">
                 <span class="wc-tip-label">Tip</span>
-                Press <kbd>1</kbd>–<kbd>5</kbd> to jump to any action, or open the Command Palette with <kbd>⌘⇧P</kbd>.
+                Press <kbd>1</kbd>–<kbd>6</kbd> to jump to any action, or open the Command Palette with <kbd>⌘⇧P</kbd>.
             </p>
-            <p class="wc-version">FlowCraft v2.1.0</p>
+            <p class="wc-version">FlowCraft v2.2.0</p>
         </footer>
     </main>
 

--- a/src/webview/welcome/welcome.js
+++ b/src/webview/welcome/welcome.js
@@ -4,6 +4,7 @@ import { getById } from '../shared/utils/dom.js';
 const ACTIONS = [
   { id: 'action-diagram',     command: 'generateDiagram' },
   { id: 'action-selection',   command: 'generateFromSelection' },
+  { id: 'action-file',        command: 'generateFromFile' },
   { id: 'action-infographic', command: 'createInfographic' },
   { id: 'action-image',       command: 'generateImage' },
   { id: 'action-history',     command: 'viewHistory' },
@@ -51,6 +52,20 @@ function wireLinks() {
     settings.addEventListener('click', (e) => {
       e.preventDefault();
       postMessage('openSettings');
+    });
+  }
+  const resetKeys = getById('link-reset-keys');
+  if (resetKeys) {
+    resetKeys.addEventListener('click', (e) => {
+      e.preventDefault();
+      postMessage('resetApiKeys');
+    });
+  }
+  const syncUsage = getById('link-sync-usage');
+  if (syncUsage) {
+    syncUsage.addEventListener('click', (e) => {
+      e.preventDefault();
+      postMessage('syncUsage');
     });
   }
 }


### PR DESCRIPTION
## Summary
- Refreshes the Welcome and Settings webviews (src/ + media/ copies kept in sync).
- Fixes a bug where `flowcraft.showHistory` always rendered empty: the four legacy raw-fetch generation commands (flowchart/class × whole-file/selection) were bypassing `StateManager`. Introduces a shared `persistRawFetchDiagram` helper in `src/extension.ts` that constructs a `Diagram` from the API response and calls `stateManager.addDiagram()` before opening the result in the browser. Persistence is best-effort — failures are logged but never block the success path.
- Ships version bump to 2.1.2 (already on `main` locally, rolled into this PR).

## Test plan
- [ ] `npm run compile` passes
- [ ] F5 into Extension Dev Host; run `flowcraft.generateFromFile` → diagram opens in browser AND appears in `flowcraft.showHistory`
- [ ] Repeat for `flowcraft.generateFromSelection`, `flowcraft.generateClassDiagram`, `flowcraft.generateClassDiagramFromSelection` — all four show up in history with correct type (flowchart vs class)
- [ ] Reload the window and re-run `flowcraft.showHistory` — entries persist (confirms `StateManager.persist()` fired)
- [ ] Force-fail the API (bad key) → no phantom entry added, error message still shown
- [ ] Welcome and Settings sidebar views render correctly and behave as before